### PR TITLE
Prevent stealing focus back when clicking an outside control

### DIFF
--- a/MultiSelectComboBox/Sdl.MultiSelectComboBox/Themes/Generic/MultiSelectComboBox.cs
+++ b/MultiSelectComboBox/Sdl.MultiSelectComboBox/Themes/Generic/MultiSelectComboBox.cs
@@ -1,4 +1,4 @@
-﻿using Sdl.MultiSelectComboBox.API;
+using Sdl.MultiSelectComboBox.API;
 using Sdl.MultiSelectComboBox.Controls;
 using Sdl.MultiSelectComboBox.EventArgs;
 using Sdl.MultiSelectComboBox.Services;
@@ -368,11 +368,14 @@ namespace Sdl.MultiSelectComboBox.Themes.Generic
 			MultiSelectComboBox comboBox = sender as MultiSelectComboBox;
 			if (comboBox != null)
 			{
+				if (comboBox.IsDropDownOpen)
+					comboBox.IgnoreDropdownClosingFocusPlanUntil = DateTime.Now.AddSeconds(1);
 				comboBox.CloseDropdownMenu(comboBox.ClearFilterOnDropdownClosing, false);
 				comboBox.CaptureMouse();
 				comboBox.ReleaseMouseCapture();
 			}
 		}
+		private DateTime? IgnoreDropdownClosingFocusPlanUntil;
 
 		public override void OnApplyTemplate()
 		{
@@ -1234,6 +1237,11 @@ namespace Sdl.MultiSelectComboBox.Themes.Generic
 
 		private void DropdownMenuClosed(object sender, System.EventArgs e)
 		{
+			if (IgnoreDropdownClosingFocusPlanUntil > DateTime.Now)
+			{
+				IgnoreDropdownClosingFocusPlanUntil = null;//so only the first is ignored
+				return;
+			}
 			FocusCursorOnFilterTextBox();
 		}
 


### PR DESCRIPTION
Closes #60

An example of this would just be two of our comboboxes next to each other with "OpenDropDownListAlsoWhenNotInEditMode" set to true.  Click the first opening the dropdown then click the second.   The second dropdown will open temporarily but then close as the first steals back control on dropdown closing.

I was unable to figure out a better way to do this.   The dropdown is destroyed before virtually all other indicators would work.  I looked at:
- HasEffectiveKeyboardFocus
- IsKeyboardFocusWithin
- IsFocused
- MultiSelectComboBoxHasFocus
While the closing of the dropdown is caused by OnPreviewMouseDownOutside it also actually starts closing after that function finishes so we can't just set a variable while it is open.  We could use a simple bool to ignore just the next close focus request, however if the close isn't triggered for some reason then didn't want it to randomly cancel the next one.  This ensures only the next close request is ignored, and only if it happens within OnPreviewMouseDownOutside starting a seemingly valid dropdown close call.

