### PR TITLE
Fix EditMode not working until item selected as filter placeholder missing

### DIFF
--- a/MultiSelectComboBox/Sdl.MultiSelectComboBox/Themes/Generic/MultiSelectComboBox.cs
+++ b/MultiSelectComboBox/Sdl.MultiSelectComboBox/Themes/Generic/MultiSelectComboBox.cs
@@ -1612,6 +1612,8 @@ namespace Sdl.MultiSelectComboBox.Themes.Generic
 
 		private void AssignIsEditMode()
 		{
+			if (SelectedItemsInternal?.Count == 0)//no placeholder exists by default
+				SelectedItemsInternal.Add(null);
 			SetValue(IsEditModePropertyKey, true);
 
 			FocusCursorOnFilterTextBox();


### PR DESCRIPTION
As there is no filter placeholder in the selected items you cannot type until it gets added, which only happens right now when the selected items container gets updated.   I don't know the code well enough to know if there is a chance the placeholder gets removed, if so this should be changed to a contains check rather than a count=0 check.

Closes #63