### PR TITLE
Allow main control to resize dynamically when not container bound

### DIFF
--- a/MultiSelectComboBox/Sdl.MultiSelectComboBox/Themes/Generic/MultiSelectComboBox.xaml
+++ b/MultiSelectComboBox/Sdl.MultiSelectComboBox/Themes/Generic/MultiSelectComboBox.xaml
@@ -370,7 +370,7 @@
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type generic:MultiSelectComboBox}">
 
-                    <Grid x:Name="PART_MultiSelectComboBox" MaxHeight="{TemplateBinding ActualHeight}" MaxWidth="{TemplateBinding ActualWidth}" Style="{StaticResource MultiSelectComboBox.Style}">
+                    <Grid x:Name="PART_MultiSelectComboBox" Style="{StaticResource MultiSelectComboBox.Style}">
                         <ToggleButton KeyboardNavigation.TabNavigation="None" IsChecked="{Binding Path=IsDropDownOpen, Mode=TwoWay, RelativeSource={RelativeSource TemplatedParent}}" IsTabStop="False">
                             <ToggleButton.Template>
                                 <ControlTemplate TargetType="ToggleButton">


### PR DESCRIPTION
I am not sure if the maxheight/maxwidth settings below were intended.  I don't think they serve a useful purpose.
Maybe this is a dangerous change and I am not seeing why it was set in the first place.

The control currently stretches when forced (ie in a container that has a fixed width and the control is set to stretch alignment).  If it is more in a free form contained sizing situation it essentially sticks to its minimum size and adds a scrollbar.    Setting these to MinWidth/Height instead of Max does allow it to grow, but then keeps it at the grown size even if the number of selected items decreases.   Removing it all together seems to work well.  It works to grow horizontally to max constrained size before growing vertically and only introduces scrollbars if both limits are encountered.

User can constrain this like normal by setting max width/height on the control itself.