### PR TITLE
Support for pasting selected items

### DIFF
--- a/MultiSelectComboBox/MultiSelectComboBox.Example/MainWindow.xaml
+++ b/MultiSelectComboBox/MultiSelectComboBox.Example/MainWindow.xaml
@@ -12,93 +12,94 @@
         mc:Ignorable="d"  
         Title="Sdl.MultiSelectComboBox Example" Height="600" MinHeight="540" Width="934">
 
-	<Window.Resources>
-		<ResourceDictionary>
-			<ResourceDictionary.MergedDictionaries>
-				<ResourceDictionary Source="Styles/MultiSelectComboBox.Custom.ControlTemplate.xaml"/>
-				<ResourceDictionary Source="Styles/MultiSelectComboBox.Custom.DropdownItemTemplate.xaml"/>
-				<ResourceDictionary Source="Styles/MultiSelectComboBox.Custom.SelectedItemTemplate.xaml"/>
-			</ResourceDictionary.MergedDictionaries>
+    <Window.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="Styles/MultiSelectComboBox.Custom.ControlTemplate.xaml"/>
+                <ResourceDictionary Source="Styles/MultiSelectComboBox.Custom.DropdownItemTemplate.xaml"/>
+                <ResourceDictionary Source="Styles/MultiSelectComboBox.Custom.SelectedItemTemplate.xaml"/>
+            </ResourceDictionary.MergedDictionaries>
 
-			<converters:BoolToVisibilityConverter x:Key="BoolToVis" />
+            <converters:BoolToVisibilityConverter x:Key="BoolToVis" />
 
-			<Style x:Key="Custom.Button.Style" TargetType="{x:Type Button}">
-				<Setter Property="Foreground" Value="RoyalBlue"/>
-				<Setter Property="Background" Value="{x:Null}"/>
-				<Setter Property="BorderBrush" Value="{x:Null}"/>
-				<Setter Property="BorderThickness" Value="0"/>
-				<Setter Property="HorizontalContentAlignment" Value="Right"/>
-				<Setter Property="VerticalContentAlignment" Value="Center"/>
-				<Setter Property="VerticalAlignment" Value="Bottom"/>
-				<Setter Property="HorizontalAlignment" Value="Right"/>
-				<Setter Property="Padding" Value="1"/>
-				<Setter Property="Margin" Value="0"/>
-				<Setter Property="Cursor" Value="Hand"/>
-				<Setter Property="IsTabStop" Value="True" />
-				<Setter Property="Template">
-					<Setter.Value>
-						<ControlTemplate TargetType="Button">
-							<Border x:Name="border" TextBlock.Foreground="{TemplateBinding Foreground}" BorderThickness="1,0,1,1" BorderBrush="Transparent" Background="Transparent">
-								<ContentPresenter Margin="0" HorizontalAlignment="{TemplateBinding HorizontalAlignment}" VerticalAlignment="{TemplateBinding VerticalAlignment}" RecognizesAccessKey="False" />
-							</Border>
-							<ControlTemplate.Triggers>
-								<Trigger Property="IsMouseOver" Value="True">
-									<Setter Property="Background" TargetName="border" Value="{x:Null}"/>
-									<Setter Property="BorderBrush" TargetName="border" Value="{x:Null}"/>
-								</Trigger>
-							</ControlTemplate.Triggers>
-						</ControlTemplate>
-					</Setter.Value>
-				</Setter>
-			</Style>
+            <Style x:Key="Custom.Button.Style" TargetType="{x:Type Button}">
+                <Setter Property="Foreground" Value="RoyalBlue"/>
+                <Setter Property="Background" Value="{x:Null}"/>
+                <Setter Property="BorderBrush" Value="{x:Null}"/>
+                <Setter Property="BorderThickness" Value="0"/>
+                <Setter Property="HorizontalContentAlignment" Value="Right"/>
+                <Setter Property="VerticalContentAlignment" Value="Center"/>
+                <Setter Property="VerticalAlignment" Value="Bottom"/>
+                <Setter Property="HorizontalAlignment" Value="Right"/>
+                <Setter Property="Padding" Value="1"/>
+                <Setter Property="Margin" Value="0"/>
+                <Setter Property="Cursor" Value="Hand"/>
+                <Setter Property="IsTabStop" Value="True" />
+                <Setter Property="Template">
+                    <Setter.Value>
+                        <ControlTemplate TargetType="Button">
+                            <Border x:Name="border" TextBlock.Foreground="{TemplateBinding Foreground}" BorderThickness="1,0,1,1" BorderBrush="Transparent" Background="Transparent">
+                                <ContentPresenter Margin="0" HorizontalAlignment="{TemplateBinding HorizontalAlignment}" VerticalAlignment="{TemplateBinding VerticalAlignment}" RecognizesAccessKey="False" />
+                            </Border>
+                            <ControlTemplate.Triggers>
+                                <Trigger Property="IsMouseOver" Value="True">
+                                    <Setter Property="Background" TargetName="border" Value="{x:Null}"/>
+                                    <Setter Property="BorderBrush" TargetName="border" Value="{x:Null}"/>
+                                </Trigger>
+                            </ControlTemplate.Triggers>
+                        </ControlTemplate>
+                    </Setter.Value>
+                </Setter>
+            </Style>
 
-		</ResourceDictionary>
-	</Window.Resources>
+        </ResourceDictionary>
+    </Window.Resources>
 
-	<Grid Margin="15">
+    <Grid Margin="15">
 
-		<DockPanel LastChildFill="True">
-			<Grid DockPanel.Dock="Top">
+        <DockPanel LastChildFill="True">
+            <Grid DockPanel.Dock="Top">
 
-				<Grid.ColumnDefinitions>
-					<ColumnDefinition Width="*" />
-					<ColumnDefinition Width="5" />
-					<ColumnDefinition Width="*" />
-				</Grid.ColumnDefinitions>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="5" />
+                    <ColumnDefinition Width="*" />
+                </Grid.ColumnDefinitions>
 
-				<Grid DockPanel.Dock="Left" Grid.Column="0" Margin="0,0,2,25" MinWidth="150" Width="Auto" >
-					<Grid>
-						<Grid.ColumnDefinitions>
-							<ColumnDefinition Width="Auto"/>
-							<ColumnDefinition Width="*"/>
-						</Grid.ColumnDefinitions>
+                <Grid DockPanel.Dock="Left" Grid.Column="0" Margin="0,0,2,25" MinWidth="150" Width="Auto" >
+                    <Grid>
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="Auto"/>
+                            <ColumnDefinition Width="*"/>
+                        </Grid.ColumnDefinitions>
 
-						<TextBlock Grid.Column="0" Grid.Row="0" Text ="Items" Margin="0,5,0,0" HorizontalAlignment="Left" FontWeight="DemiBold" Width="120" Height="21" VerticalAlignment="Top"/>
-						<TextBlock Grid.Column="1" Grid.Row="0" HorizontalAlignment="Right" FontWeight="DemiBold" Margin="0,5,0,0" Height="21" VerticalAlignment="Top">
+                        <TextBlock Grid.Column="0" Grid.Row="0" Text ="Items" Margin="0,5,0,0" HorizontalAlignment="Left" FontWeight="DemiBold" Width="120" Height="21" VerticalAlignment="Top"/>
+                        <TextBlock Grid.Column="1" Grid.Row="0" HorizontalAlignment="Right" FontWeight="DemiBold" Margin="0,5,0,0" Height="21" VerticalAlignment="Top">
                             <InlineUIContainer>
                                 <StackPanel Orientation="Horizontal">
                                     <TextBox Text="{Binding SelectedItemsCount, FallbackValue=0}" HorizontalContentAlignment="Right" BorderThickness="0" Background="Transparent" IsTabStop="False"/>
                                     <TextBox Text="Selected" HorizontalContentAlignment="Right" BorderThickness="0" IsTabStop="False" />
                                 </StackPanel>
                             </InlineUIContainer>
-						</TextBlock>
-					</Grid>
+                        </TextBlock>
+                    </Grid>
 
-					<Grid Margin="0,25,0,0">
-						<Grid.RowDefinitions>
-							<RowDefinition Height="100" MinHeight="49" MaxHeight="300" />
-							<RowDefinition Height="10" />
-							<RowDefinition Height="*" />
-						</Grid.RowDefinitions>
+                    <Grid Margin="0,25,0,0">
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="100" MinHeight="49" MaxHeight="300" />
+                            <RowDefinition Height="10" />
+                            <RowDefinition Height="*" />
+                        </Grid.RowDefinitions>
 
-						<Grid Grid.Row="0">
+                        <Grid Grid.Row="0">
 
-							<sdl:MultiSelectComboBox Margin="0,0,0,20"
+                            <sdl:MultiSelectComboBox Margin="0,0,0,20"
                                                      Visibility="{Binding ElementName=RadioButtonDefaultStyle, Converter={StaticResource BoolToVis}, Path=IsChecked}"  
                                                      SelectedItemTemplate="{StaticResource MultiSelectComboBox.SelectedItems.ItemTemplate}"
                                                      DropdownItemTemplate="{StaticResource MultiSelectComboBox.Dropdown.ListBox.ItemTemplate}"                                 
                                                      MaxDropDownHeight="300"
                                                      EnableAutoComplete="{Binding EnableAutoComplete}"
+                                                     EnableBatchSelection="{Binding EnableBatchSelection}"
                                                      ClearFilterOnDropdownClosing="{Binding ClearFilterOnDropdownClosing}"
                                                      SelectionMode="{Binding SelectionMode}"
                                                      IsEditable="{Binding IsEditable}"                                
@@ -120,6 +121,7 @@
                                                      DropdownItemTemplate="{StaticResource MultiSelectComboBox.Dropdown.ListBox.Custom.ItemTemplate}"                                                                           
                                                      MaxDropDownHeight="350"
                                                      EnableAutoComplete="{Binding EnableAutoComplete}"
+                                                     EnableBatchSelection="{Binding EnableBatchSelection}"
                                                      ClearFilterOnDropdownClosing="{Binding ClearFilterOnDropdownClosing}"
                                                      IsEditable="{Binding IsEditable}"
                                                      SelectionMode="{Binding SelectionMode}"
@@ -134,82 +136,83 @@
                                                      sdl:SelectedItemsChangedBehaviour.SelectedItemsChanged="{Binding SelectedItemsChangedCommand}"/>
 
                             <Button Command="{Binding ClearItemsCommand}" Style="{StaticResource Custom.Button.Style}"  Width="128" Height="20">
-								<Underline>Clear selected items</Underline>
-							</Button>
-						</Grid>
+                                <Underline>Clear selected items</Underline>
+                            </Button>
+                        </Grid>
 
-						<GridSplitter DockPanel.Dock="Top" Height="2" VerticalContentAlignment="Stretch" Grid.Row="1" Margin="5,0,5,0" HorizontalAlignment="Stretch" IsTabStop="False"/>
+                        <GridSplitter DockPanel.Dock="Top" Height="2" VerticalContentAlignment="Stretch" Grid.Row="1" Margin="5,0,5,0" HorizontalAlignment="Stretch" IsTabStop="False"/>
 
-						<ScrollViewer Grid.Row="2" VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Auto" Margin="0,5,0,0">
-							<Border BorderBrush="LightGray" BorderThickness="1">
-								<Grid>
+                        <ScrollViewer Grid.Row="2" VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Auto" Margin="0,5,0,0">
+                            <Border BorderBrush="LightGray" BorderThickness="1">
+                                <Grid>
 
-									<TextBlock Text ="Demo Settings" Margin="9,4,0,0" HorizontalAlignment="Left" FontWeight="DemiBold" Width="95" Height="21" VerticalAlignment="Top" />
+                                    <TextBlock Text ="Demo Settings" Margin="9,4,0,0" HorizontalAlignment="Left" FontWeight="DemiBold" Width="95" Height="21" VerticalAlignment="Top" />
 
-									<Label Content="Style:" Margin="27,26,0,0" HorizontalAlignment="Left" Width="48" Height="26" VerticalAlignment="Top" />
+                                    <Label Content="Style:" Margin="27,26,0,0" HorizontalAlignment="Left" Width="48" Height="26" VerticalAlignment="Top" />
 
-									<Grid Margin="64,25,0,0" Height="50" VerticalAlignment="Top" HorizontalAlignment="Left" Width="210">
-										<Grid.RowDefinitions>
-											<RowDefinition Height="19*"/>
-											<RowDefinition Height="31*"/>
-										</Grid.RowDefinitions>
-										<Grid.ColumnDefinitions>
-											<ColumnDefinition Width="Auto"/>
-											<ColumnDefinition Width="*"/>
-										</Grid.ColumnDefinitions>
+                                    <Grid Margin="64,25,0,0" Height="50" VerticalAlignment="Top" HorizontalAlignment="Left" Width="210">
+                                        <Grid.RowDefinitions>
+                                            <RowDefinition Height="19*"/>
+                                            <RowDefinition Height="31*"/>
+                                        </Grid.RowDefinitions>
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition Width="Auto"/>
+                                            <ColumnDefinition Width="*"/>
+                                        </Grid.ColumnDefinitions>
 
-										<StackPanel Orientation="Vertical" Grid.Column="0" Margin="10,6,-74,0" Grid.ColumnSpan="2" Grid.RowSpan="2">
-											<RadioButton x:Name="RadioButtonDefaultStyle" GroupName="Style" Content="Default control template style" Margin="1" IsChecked="True" Command="{Binding StyleChangedCommand}" CommandParameter="{Binding RelativeSource={RelativeSource Self}}"/>
-											<RadioButton x:Name="RadioButtonCustomStyle" GroupName="Style" Content="Custom control template style" Margin="1" Command="{Binding StyleChangedCommand}" CommandParameter="{Binding RelativeSource={RelativeSource Self}}"/>
-										</StackPanel>
-									</Grid>
+                                        <StackPanel Orientation="Vertical" Grid.Column="0" Margin="10,6,-74,0" Grid.ColumnSpan="2" Grid.RowSpan="2">
+                                            <RadioButton x:Name="RadioButtonDefaultStyle" GroupName="Style" Content="Default control template style" Margin="1" IsChecked="True" Command="{Binding StyleChangedCommand}" CommandParameter="{Binding RelativeSource={RelativeSource Self}}"/>
+                                            <RadioButton x:Name="RadioButtonCustomStyle" GroupName="Style" Content="Custom control template style" Margin="1" Command="{Binding StyleChangedCommand}" CommandParameter="{Binding RelativeSource={RelativeSource Self}}"/>
+                                        </StackPanel>
+                                    </Grid>
 
 
-									<Button Content="Select 20 random items" Command="{Binding SelectRandomItemsCommand}" HorizontalContentAlignment="Center" VerticalContentAlignment="Top" HorizontalAlignment="Left" Margin="30,76,0,0" VerticalAlignment="Top" Grid.Column="0" Height="23" Width="184"/>
+                                    <Button Content="Select 20 random items" Command="{Binding SelectRandomItemsCommand}" HorizontalContentAlignment="Center" VerticalContentAlignment="Top" HorizontalAlignment="Left" Margin="30,76,0,0" VerticalAlignment="Top" Grid.Column="0" Height="23" Width="184"/>
 
-									<Label Content="Selection Mode:" HorizontalContentAlignment="Left" HorizontalAlignment="Left" Margin="27,104,0,0" VerticalContentAlignment="Center" VerticalAlignment="Top" Width="97"/>
-									<ComboBox HorizontalAlignment="Left" Margin="126,106,0,0" VerticalAlignment="Top" Width="88" SelectedItem="{Binding SelectionMode}" ItemsSource="{Binding SelectionModes}"/>
+                                    <Label Content="Selection Mode:" HorizontalContentAlignment="Left" HorizontalAlignment="Left" Margin="27,104,0,0" VerticalContentAlignment="Center" VerticalAlignment="Top" Width="97"/>
+                                    <ComboBox HorizontalAlignment="Left" Margin="126,106,0,0" VerticalAlignment="Top" Width="88" SelectedItem="{Binding SelectionMode}" ItemsSource="{Binding SelectionModes}"/>
 
-									<CheckBox Content="Clear Filter Criteria as Dropdown (with Keyboard focus) is closing" IsChecked="{Binding ClearFilterOnDropdownClosing}" HorizontalAlignment="Left" Margin="29,142,0,0" VerticalAlignment="Top" Grid.Column="0" Width="364"/>
+                                    <CheckBox Content="Clear Filter Criteria as Dropdown (with Keyboard focus) is closing" IsChecked="{Binding ClearFilterOnDropdownClosing}" HorizontalAlignment="Left" Margin="29,142,0,0" VerticalAlignment="Top" Grid.Column="0" Width="364"/>
 
-									<CheckBox Content="Items in the 'Selected Items Panel' are editable" IsChecked="{Binding IsEditable}" HorizontalAlignment="Left" Margin="29,159,0,0" VerticalAlignment="Top" Grid.Column="0" Width="313"/>
+                                    <CheckBox Content="Items in the 'Selected Items Panel' are editable" IsChecked="{Binding IsEditable}" HorizontalAlignment="Left" Margin="29,159,0,0" VerticalAlignment="Top" Grid.Column="0" Width="313"/>
 
-									<CheckBox Content="Enable/disable items (alternate)" IsChecked="{Binding EnableAlternateItems}" HorizontalAlignment="Left" Margin="29,176,0,0" VerticalAlignment="Top" Grid.Column="0" Width="313"/>
+                                    <CheckBox Content="Enable/disable items (alternate)" IsChecked="{Binding EnableAlternateItems}" HorizontalAlignment="Left" Margin="29,176,0,0" VerticalAlignment="Top" Grid.Column="0" Width="313"/>
 
-									<CheckBox Content="Listen to 'Filter Text' changed" IsChecked="{Binding ListenToFilterTextChanged}" HorizontalAlignment="Left" Margin="29,193,0,0" VerticalAlignment="Top" Grid.Column="0" Width="314"/>
-									<CheckBox Content="Listen to 'Selected Items' changed" IsChecked="{Binding ListenToSelectedItemsChanged}" HorizontalAlignment="Left" Margin="29,211,0,0" VerticalAlignment="Top" Grid.Column="0" Width="314"/>
+                                    <CheckBox Content="Listen to 'Filter Text' changed" IsChecked="{Binding ListenToFilterTextChanged}" HorizontalAlignment="Left" Margin="29,193,0,0" VerticalAlignment="Top" Grid.Column="0" Width="314"/>
+                                    <CheckBox Content="Listen to 'Selected Items' changed" IsChecked="{Binding ListenToSelectedItemsChanged}" HorizontalAlignment="Left" Margin="29,211,0,0" VerticalAlignment="Top" Grid.Column="0" Width="314"/>
 
-									<CheckBox Content="Enable Autocomplete" IsChecked="{Binding EnableAutoComplete}" HorizontalAlignment="Left" Margin="29,229,0,0" VerticalAlignment="Top" Grid.Column="0" Width="314"/>
+                                    <CheckBox Content="Enable Autocomplete" IsChecked="{Binding EnableAutoComplete}" HorizontalAlignment="Left" Margin="29,229,0,0" VerticalAlignment="Top" Grid.Column="0" Width="314"/>
+                                    <CheckBox Content="Enable batch selection (paste support)" IsChecked="{Binding EnableBatchSelection}" IsEnabled="{Binding EnableAutoComplete}" HorizontalAlignment="Left" Margin="45,247,0,0" VerticalAlignment="Top" Grid.Column="0" Width="314"/>
 
-									<CheckBox Content="Enable grouping" IsChecked="{Binding EnableGrouping}" HorizontalAlignment="Left" Margin="29,247,0,0" VerticalAlignment="Top" Grid.Column="0" Width="314"/>
-									<CheckBox Content="Use 'Recently Used' service" IsChecked="{Binding UseRecentlyUsedGroupingService}" IsEnabled="{Binding EnableGrouping}"  HorizontalAlignment="Left" Margin="45,265,0,0" VerticalAlignment="Top" Grid.Column="0" Width="314"/>
+                                    <CheckBox Content="Enable grouping" IsChecked="{Binding EnableGrouping}" HorizontalAlignment="Left" Margin="29,267,0,0" VerticalAlignment="Top" Grid.Column="0" Width="314"/>
+                                    <CheckBox Content="Use 'Recently Used' service" IsChecked="{Binding UseRecentlyUsedGroupingService}" IsEnabled="{Binding EnableGrouping}"  HorizontalAlignment="Left" Margin="45,285,0,0" VerticalAlignment="Top" Grid.Column="0" Width="314"/>
 
-									<CheckBox Content="Enable filtering" IsChecked="{Binding EnableFiltering}" HorizontalAlignment="Left" Margin="30,285,0,0" VerticalAlignment="Top" Grid.Column="0" Width="314"/>
-									<CheckBox Content="Use 'Custom Filter' service" IsChecked="{Binding UseCustomFilterService}" IsEnabled="{Binding EnableFiltering}" HorizontalAlignment="Left" Margin="45,305,0,0" VerticalAlignment="Top" Grid.Column="0" Width="314"/>
+                                    <CheckBox Content="Enable filtering" IsChecked="{Binding EnableFiltering}" HorizontalAlignment="Left" Margin="30,305,0,0" VerticalAlignment="Top" Grid.Column="0" Width="314"/>
+                                    <CheckBox Content="Use 'Custom Filter' service" IsChecked="{Binding UseCustomFilterService}" IsEnabled="{Binding EnableFiltering}" HorizontalAlignment="Left" Margin="45,323,0,0" VerticalAlignment="Top" Grid.Column="0" Width="314"/>
 
-									<CheckBox Content="Clear selection on filter changed (Single selection mode only)" IsChecked="{Binding ClearSelectionOnFilterChanged}" Margin="30,325,10,0" VerticalAlignment="Top" Grid.Column="0"/>
+                                    <CheckBox Content="Clear selection on filter changed (Single selection mode only)" IsChecked="{Binding ClearSelectionOnFilterChanged}" Margin="30,343,10,0" VerticalAlignment="Top" Grid.Column="0"/>
 
-                                    <CheckBox Content="Enable on demand service" IsChecked="{Binding EnableSuggestionProvider}" Margin="30,345,10,0" VerticalAlignment="Top" Grid.Column="0"/>
+                                    <CheckBox Content="Enable on demand service" IsChecked="{Binding EnableSuggestionProvider}" Margin="30,363,10,0" VerticalAlignment="Top" Grid.Column="0"/>
                                 </Grid>
-							</Border>
-						</ScrollViewer>
+                            </Border>
+                        </ScrollViewer>
 
-					</Grid>
+                    </Grid>
 
-				</Grid>
+                </Grid>
 
-				<GridSplitter DockPanel.Dock="Left" VerticalAlignment="Stretch" Width="2" Grid.Column="1" HorizontalAlignment="Stretch" Margin="0,25,0,40"/>
+                <GridSplitter DockPanel.Dock="Left" VerticalAlignment="Stretch" Width="2" Grid.Column="1" HorizontalAlignment="Stretch" Margin="0,25,0,40"/>
 
-				<Grid DockPanel.Dock="Right" Grid.Column="2" Width="Auto" MinWidth="150" Margin="2,0,0,0" >
-					<TextBlock Text="Events Log" HorizontalAlignment="Left" VerticalAlignment="Top" Padding="0,5,0,0" FontWeight="Medium" Height="26" />
-					<TextBox Text="{Binding EventLog}" TextWrapping="NoWrap" IsReadOnly="True" Margin="0,25,0,24" VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Auto"  TextChanged="TextBoxBase_OnTextChanged"/>
-					<Button Command="{Binding ClearLogCommand}" Style="{StaticResource Custom.Button.Style}" Width="75" Height="24">
-						<Underline>Clear log</Underline>
-					</Button>
-				</Grid>
-			</Grid>
-		</DockPanel>
-	</Grid>
+                <Grid DockPanel.Dock="Right" Grid.Column="2" Width="Auto" MinWidth="150" Margin="2,0,0,0" >
+                    <TextBlock Text="Events Log" HorizontalAlignment="Left" VerticalAlignment="Top" Padding="0,5,0,0" FontWeight="Medium" Height="26" />
+                    <TextBox Text="{Binding EventLog}" TextWrapping="NoWrap" IsReadOnly="True" Margin="0,25,0,24" VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Auto"  TextChanged="TextBoxBase_OnTextChanged"/>
+                    <Button Command="{Binding ClearLogCommand}" Style="{StaticResource Custom.Button.Style}" Width="75" Height="24">
+                        <Underline>Clear log</Underline>
+                    </Button>
+                </Grid>
+            </Grid>
+        </DockPanel>
+    </Grid>
 </Window>
 
 

--- a/MultiSelectComboBox/MultiSelectComboBox.Example/Models/LanguageItems.cs
+++ b/MultiSelectComboBox/MultiSelectComboBox.Example/Models/LanguageItems.cs
@@ -23,6 +23,7 @@ namespace Sdl.MultiSelectComboBox.Example.Models
 		private bool _listenToFilterTextChanged;
 		private bool _listenToSelectedItemsChanged;
 		private bool _enableAutoComplete;
+		private bool _enableBatchSelection;
 		private bool _enableGrouping;
 		private bool _useRecentlyUsedGroupingService;
 		private bool _enableFiltering;
@@ -51,6 +52,7 @@ namespace Sdl.MultiSelectComboBox.Example.Models
 			UseRecentlyUsedGroupingService = true;
 
 			EnableAutoComplete = true;
+			EnableBatchSelection = true;
 
 			FilterTextChangedCommand = new FilterTextChangedCommand(UpdateEventLog, CanListenToFilterTextChangedExample);
 			SelectedItemsChangedCommand = new SelectedItemsChangedCommand(UpdateEventLog, UpdateSelectedItems, CanListenToSelectedItemsChangedExample);
@@ -137,6 +139,24 @@ namespace Sdl.MultiSelectComboBox.Example.Models
 				UpdateEventLog(nameof(EnableAutoComplete), _enableAutoComplete.ToString());
 
 				OnPropertyChanged(nameof(EnableAutoComplete));
+			}
+		}
+
+		public bool EnableBatchSelection
+		{
+			get => _enableBatchSelection;
+			set
+			{
+				if (_enableBatchSelection.Equals(value))
+				{
+					return;
+				}
+
+				_enableBatchSelection = value;
+
+				UpdateEventLog(nameof(EnableBatchSelection), _enableBatchSelection.ToString());
+
+				OnPropertyChanged(nameof(EnableBatchSelection));
 			}
 		}
 

--- a/MultiSelectComboBox/Sdl.MultiSelectComboBox/Themes/Generic/MultiSelectComboBox.cs
+++ b/MultiSelectComboBox/Sdl.MultiSelectComboBox/Themes/Generic/MultiSelectComboBox.cs
@@ -475,6 +475,16 @@ namespace Sdl.MultiSelectComboBox.Themes.Generic
 			Single
 		}
 
+		public static readonly DependencyProperty EnableBatchSelectionProperty =
+			DependencyProperty.Register("EnableBatchSelection", typeof(bool), typeof(MultiSelectComboBox),
+				new FrameworkPropertyMetadata(false));
+
+		public bool EnableBatchSelection
+		{
+			get => (bool)GetValue(EnableBatchSelectionProperty);
+			set => SetValue(EnableBatchSelectionProperty, value);
+		}
+
 		public static readonly DependencyProperty EnableAutoCompleteProperty =
 			DependencyProperty.Register("EnableAutoComplete", typeof(bool), typeof(MultiSelectComboBox),
 				new FrameworkPropertyMetadata(true, FrameworkPropertyMetadataOptions.BindsTwoWayByDefault));
@@ -1644,26 +1654,72 @@ namespace Sdl.MultiSelectComboBox.Themes.Generic
 
 		private void UpdateAutoCompleteFilterText(string criteria, object item)
 		{
-			if (EnableAutoComplete && IsDropDownOpen && item != null && !IsSelectedItem(item) && SelectedItemsFilterAutoCompleteTextBox != null)
-			{
-				string autoCompleteString = CurrentAutoCompleteService.GetAutoCompleteString(item) ?? string.Empty;
-				var index = criteria?.Length > 0 ? autoCompleteString.IndexOf(criteria, StringComparison.InvariantCultureIgnoreCase) : 0;
-				var autoCompleteText = index > -1 ? autoCompleteString.Substring(index + (criteria?.Length ?? 0)) : string.Empty;
+			if (SelectedItemsFilterAutoCompleteTextBox == null)
+            {
+				return;
+            }
 
-				if (AutoCompleteMaxLength > 0 && autoCompleteText.Length >= AutoCompleteMaxLength)
-				{
-					autoCompleteText = autoCompleteText.Substring(0, AutoCompleteMaxLength) + "...";
+			if (EnableAutoComplete && IsDropDownOpen)
+			{
+				if (SelectionMode == SelectionModes.Multiple && EnableBatchSelection && TrySelectBatchItemsAsync(criteria))
+                {
+					Dispatcher.BeginInvoke((Action)delegate {
+						CloseDropdownMenu(true, true);
+						AssignIsEditMode();
+					}, DispatcherPriority.ContextIdle);
 				}
+				else if (item != null && !IsSelectedItem(item))
+				{
+					string autoCompleteString = CurrentAutoCompleteService.GetAutoCompleteString(item) ?? string.Empty;
+					var index = criteria?.Length > 0 ? autoCompleteString.IndexOf(criteria, StringComparison.InvariantCultureIgnoreCase) : 0;
+					var autoCompleteText = index > -1 ? autoCompleteString.Substring(index + (criteria?.Length ?? 0)) : string.Empty;
 
-				SelectedItemsFilterAutoCompleteTextBox.Text = autoCompleteText;
+					if (AutoCompleteMaxLength > 0 && autoCompleteText.Length >= AutoCompleteMaxLength)
+					{
+						autoCompleteText = autoCompleteText.Substring(0, AutoCompleteMaxLength) + "...";
+					}
 
-				SelectedItemsFilterAutoCompleteTextBox.Background = AutoCompleteBackground;
+					SelectedItemsFilterAutoCompleteTextBox.Text = autoCompleteText;
+					SelectedItemsFilterAutoCompleteTextBox.Background = AutoCompleteBackground;
+					return;
+				}
 			}
-			else if (SelectedItemsFilterAutoCompleteTextBox != null)
+
+			SelectedItemsFilterAutoCompleteTextBox.Text = string.Empty;
+			SelectedItemsFilterAutoCompleteTextBox.Background = Brushes.Transparent;
+		}
+
+		private bool TrySelectBatchItemsAsync(string criteria)
+        {
+			if (string.IsNullOrEmpty(criteria) || ItemsSource == null || SuggestionProvider == null || SelectedItems == null)
 			{
-				SelectedItemsFilterAutoCompleteTextBox.Text = string.Empty;
-				SelectedItemsFilterAutoCompleteTextBox.Background = Brushes.Transparent;
+				return false;
 			}
+
+			var valuesToSelect = criteria.Split(',', ';')
+				.Select(i => i.Trim().ToLower())
+				.ToArray();
+
+			var suggestionProviderToken = _suggestionProviderToken = new CancellationTokenSource();
+			var itemsToSelect = valuesToSelect
+				.Select(value => SuggestionProvider.GetSuggestionsAsync(value, _suggestionProviderToken.Token).GetAwaiter().GetResult().FirstOrDefault())
+				.Where(item => item != null && valuesToSelect.Contains(item.ToString().ToLower()))
+				.ToArray();
+
+			if (itemsToSelect.Length < valuesToSelect.Length)
+			{
+				return false;
+			}
+
+			foreach (var item in itemsToSelect)
+            {
+				if (!SelectedItems.Contains(item))
+				{
+					SelectedItems.Add(item);
+				}
+			}
+
+			return true;
 		}
 
 		private void AssignIsEditMode()

--- a/MultiSelectComboBox/Sdl.MultiSelectComboBox/Themes/Generic/MultiSelectComboBox.cs
+++ b/MultiSelectComboBox/Sdl.MultiSelectComboBox/Themes/Generic/MultiSelectComboBox.cs
@@ -1655,14 +1655,14 @@ namespace Sdl.MultiSelectComboBox.Themes.Generic
 		private void UpdateAutoCompleteFilterText(string criteria, object item)
 		{
 			if (SelectedItemsFilterAutoCompleteTextBox == null)
-            {
+			{
 				return;
-            }
+			}
 
 			if (EnableAutoComplete && IsDropDownOpen)
 			{
 				if (SelectionMode == SelectionModes.Multiple && EnableBatchSelection && TrySelectBatchItemsAsync(criteria))
-                {
+				{
 					Dispatcher.BeginInvoke((Action)delegate {
 						CloseDropdownMenu(true, true);
 						AssignIsEditMode();
@@ -1690,7 +1690,7 @@ namespace Sdl.MultiSelectComboBox.Themes.Generic
 		}
 
 		private bool TrySelectBatchItemsAsync(string criteria)
-        {
+		{
 			if (string.IsNullOrEmpty(criteria) || ItemsSource == null || SuggestionProvider == null || SelectedItems == null)
 			{
 				return false;
@@ -1712,7 +1712,7 @@ namespace Sdl.MultiSelectComboBox.Themes.Generic
 			}
 
 			foreach (var item in itemsToSelect)
-            {
+			{
 				if (!SelectedItems.Contains(item))
 				{
 					SelectedItems.Add(item);


### PR DESCRIPTION
Added EnableBatchSelection to support pasting a list of items to be selected in the combo box, provided by the end user as separated by commas or semicolons (matching them by text/ToString()).

Notes:
- EnableBatchSelection is off by default
- filtering must be enabled and selection mode should be Multiple for batch selection to be supported
- all items pasted must exist in the source of items, otherwise the behavior is reverted to the original one
- if items in the source collection contain commas or semicolons within their text content, batch selection is not supported.