### PR TITLE
Select All, Clear All, Add / Remove entries,  Placeholder/ Waterrmark text, Bound collection sort order, focus tracking fix

### DIFF
--- a/MultiSelectComboBox/MultiSelectComboBox.Example/MainWindow.xaml
+++ b/MultiSelectComboBox/MultiSelectComboBox.Example/MainWindow.xaml
@@ -93,7 +93,7 @@
 
                         <Grid Grid.Row="0">
 
-                            <sdl:MultiSelectComboBox Margin="0,0,0,20"
+							<sdl:MultiSelectComboBox Margin="0,0,0,20"      EnableCreateNewItemUI="True" NewItemAddRequest="MultiSelectComboBox_NewItemAddRequest"
                                                      Visibility="{Binding ElementName=RadioButtonDefaultStyle, Converter={StaticResource BoolToVis}, Path=IsChecked}"  
                                                      SelectedItemTemplate="{StaticResource MultiSelectComboBox.SelectedItems.ItemTemplate}"
                                                      DropdownItemTemplate="{StaticResource MultiSelectComboBox.Dropdown.ListBox.ItemTemplate}"                                 

--- a/MultiSelectComboBox/MultiSelectComboBox.Example/MainWindow.xaml
+++ b/MultiSelectComboBox/MultiSelectComboBox.Example/MainWindow.xaml
@@ -93,7 +93,7 @@
 
                         <Grid Grid.Row="0">
 
-							<sdl:MultiSelectComboBox Margin="0,0,0,20"      EnableCreateNewItemUI="True" NewItemAddRequest="MultiSelectComboBox_NewItemAddRequest"
+							<sdl:MultiSelectComboBox Margin="0,0,0,20"      EnableNewItemAddUI="True" NewItemAddRequest="MultiSelectComboBox_NewItemAddRequest"
                                                      Visibility="{Binding ElementName=RadioButtonDefaultStyle, Converter={StaticResource BoolToVis}, Path=IsChecked}"  
                                                      SelectedItemTemplate="{StaticResource MultiSelectComboBox.SelectedItems.ItemTemplate}"
                                                      DropdownItemTemplate="{StaticResource MultiSelectComboBox.Dropdown.ListBox.ItemTemplate}"                                 

--- a/MultiSelectComboBox/MultiSelectComboBox.Example/MainWindow.xaml.cs
+++ b/MultiSelectComboBox/MultiSelectComboBox.Example/MainWindow.xaml.cs
@@ -1,4 +1,4 @@
-﻿using System.Linq;
+using System.Linq;
 using System.Reflection;
 using System.Windows;
 using System.Windows.Controls;
@@ -48,6 +48,15 @@ namespace Sdl.MultiSelectComboBox.Example
 				.FirstOrDefault();
 
 			return targetFrameworkAttribute.FrameworkName;
+		}
+
+		private void MultiSelectComboBox_NewItemAddRequest(object sender, EventArgs.NewItemAddRequestEventArgs e) {
+			var itm = new LanguageItem { Name = e.TypedText };
+			var li = (DataContext as LanguageItems);
+			li.Items.Add(itm);
+			li._allItems.Add(itm);
+			li.EnableSuggestionProvider = false;
+			li.EnableSuggestionProvider = true;
 		}
 	}
 }

--- a/MultiSelectComboBox/MultiSelectComboBox.Example/Models/LanguageItems.cs
+++ b/MultiSelectComboBox/MultiSelectComboBox.Example/Models/LanguageItems.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
@@ -33,7 +33,7 @@ namespace Sdl.MultiSelectComboBox.Example.Models
 		private bool _clearFilterOnDropdownClosing;
 		private bool _clearSelectionOnFilterChanged;
 		private string _selectionMode;
-        private List<LanguageItem> _allItems;
+        public List<LanguageItem> _allItems;
 
         public LanguageItems()
 		{

--- a/MultiSelectComboBox/Sdl.MultiSelectComboBox/Controls/NumberComparisonToBoolConverter.cs
+++ b/MultiSelectComboBox/Sdl.MultiSelectComboBox/Controls/NumberComparisonToBoolConverter.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows.Data;
+
+namespace Sdl.MultiSelectComboBox.Controls {
+	internal class NumberComparisonToBoolConverter : IValueConverter {
+		public int CompareToAmount { get; set; }
+		public bool LessThanNotGreater { get; set; }
+		public object Convert(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture) {
+			var num= System.Convert.ToInt32(value);
+			if (LessThanNotGreater)
+				return num < CompareToAmount;
+			else
+				return num > CompareToAmount;
+
+		}
+
+		public object ConvertBack(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture) => throw new NotImplementedException();
+	}
+}

--- a/MultiSelectComboBox/Sdl.MultiSelectComboBox/Controls/PropertyExistsToBoolConverter.cs
+++ b/MultiSelectComboBox/Sdl.MultiSelectComboBox/Controls/PropertyExistsToBoolConverter.cs
@@ -1,0 +1,28 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows.Data;
+
+namespace Sdl.MultiSelectComboBox.Controls {
+	internal class PropertyExistsToBoolConverter : IValueConverter {
+		public object Convert(object value, Type targetType, object parameter, CultureInfo culture) {
+			var type = value.GetType();
+			if (CheckedTypeCache.TryGetValue(type, out var res))
+				return res;
+			var prop = type.GetProperty(PropertyToCheck);
+			res = prop != null;
+			CheckedTypeCache[type] = res;
+			return res;
+		}
+		public string PropertyToCheck { get; set; }
+		private ConcurrentDictionary<Type, bool> CheckedTypeCache = new ConcurrentDictionary<Type, bool>();
+
+		public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture) {
+			throw new NotImplementedException();
+		}
+	}
+}

--- a/MultiSelectComboBox/Sdl.MultiSelectComboBox/EventArgs/ItemDeleteRequestEventArgs.cs
+++ b/MultiSelectComboBox/Sdl.MultiSelectComboBox/EventArgs/ItemDeleteRequestEventArgs.cs
@@ -1,0 +1,18 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+
+namespace Sdl.MultiSelectComboBox.EventArgs {
+	public class ItemDeleteRequestEventArgs : RoutedEventArgs {
+		public ICollection ItemsRemoveRequestedOn { get; }
+		internal ItemDeleteRequestEventArgs(RoutedEvent routedEvent,
+			ICollection items
+			) : base(routedEvent) {
+			ItemsRemoveRequestedOn = items;
+		}
+	}
+}

--- a/MultiSelectComboBox/Sdl.MultiSelectComboBox/EventArgs/NewItemAddRequestEventArgs.cs
+++ b/MultiSelectComboBox/Sdl.MultiSelectComboBox/EventArgs/NewItemAddRequestEventArgs.cs
@@ -1,0 +1,16 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+
+namespace Sdl.MultiSelectComboBox.EventArgs {
+	public class NewItemAddRequestEventArgs : RoutedEventArgs {
+		public string TypedText { get; }
+
+		internal NewItemAddRequestEventArgs(RoutedEvent routedEvent, string TypedText) : base(routedEvent) {
+			this.TypedText = TypedText;
+		}
+	}
+}

--- a/MultiSelectComboBox/Sdl.MultiSelectComboBox/Themes/Generic/MultiSelectComboBox.cs
+++ b/MultiSelectComboBox/Sdl.MultiSelectComboBox/Themes/Generic/MultiSelectComboBox.cs
@@ -952,6 +952,29 @@ namespace Sdl.MultiSelectComboBox.Themes.Generic
 
 		public bool IsEditMode => (bool)GetValue(IsEditModeProperty);
 
+		//WatermarkEmptyHintText
+
+		public string WatermarkEmptyHintText {
+			get => (string)GetValue(WatermarkEmptyHintTextProperty);
+			set => SetValue(WatermarkEmptyHintTextProperty, value);
+		}
+
+		public static readonly DependencyProperty WatermarkEmptyHintTextProperty =
+			DependencyProperty.Register(nameof(WatermarkEmptyHintText), typeof(string), typeof(MultiSelectComboBox),
+				new FrameworkPropertyMetadata(""));
+
+
+		public bool WatermarkFloatOnNonEmpty {
+			get => (bool)GetValue(WatermarkFloatOnNonEmptyProperty);
+			set => SetValue(WatermarkFloatOnNonEmptyProperty, value);
+		}
+
+		public static readonly DependencyProperty WatermarkFloatOnNonEmptyProperty =
+			DependencyProperty.Register(nameof(WatermarkFloatOnNonEmpty), typeof(bool), typeof(MultiSelectComboBox),
+				new FrameworkPropertyMetadata(false));
+
+
+
 		public SelectedItemTemplateService SelectedItemTemplateSelector { get; private set; }
 
 		public DropdownItemTemplateService DropdownItemTemplateSelector { get; private set; }

--- a/MultiSelectComboBox/Sdl.MultiSelectComboBox/Themes/Generic/MultiSelectComboBox.cs
+++ b/MultiSelectComboBox/Sdl.MultiSelectComboBox/Themes/Generic/MultiSelectComboBox.cs
@@ -42,6 +42,9 @@ namespace Sdl.MultiSelectComboBox.Themes.Generic
 		private const string PART_MultiSelectComboBox_SelectedItemsPanel_Filter_AutoComplete_TextBox = "PART_MultiSelectComboBox_SelectedItemsPanel_Filter_AutoComplete_TextBox";
 		private const string PART_MultiSelectComboBox_SelectedItemsPanel_RemoveItem_Button = "PART_MultiSelectComboBox_SelectedItemsPanel_RemoveItem_Button";
 		private const string PART_MultiSelectComboBox_Dropdown_NewItem_CreatedOkButton = "PART_MultiSelectComboBox_Dropdown_NewItem_CreatedOkButton";
+		private const string PART_MultiSelectComboBox_Dropdown_SelectAllButton = "PART_MultiSelectComboBox_Dropdown_SelectAllButton";
+		private const string PART_MultiSelectComboBox_Dropdown_ClearAllButton = "PART_MultiSelectComboBox_Dropdown_ClearAllButton";
+
 		private const string PART_MultiSelectComboBox_Dropdown_NewItem_TextBox = "PART_MultiSelectComboBox_Dropdown_NewItem_TextBox";
 		private const string MultiSelectComboBox_SelectedItems_Searchable_ItemTemplate = "MultiSelectComboBox.SelectedItems.Searchable.ItemTemplate";
 		private const string MultiSelectComboBox_Dropdown_ListBox_ItemTemplate = "MultiSelectComboBox.Dropdown.ListBox.ItemTemplate";
@@ -477,6 +480,13 @@ namespace Sdl.MultiSelectComboBox.Themes.Generic
 						TextBoxNewItem.KeyDown += (s, e) => { if (e.Key == Key.Enter) { e.Handled = true; NewItemCreated_Click(newItemCreated, null); } };
 					}
 				}
+				var selectAllBtn = VisualTreeService.FindVisualChild<Button>(DropdownMenu.Child, PART_MultiSelectComboBox_Dropdown_SelectAllButton); ;//
+				if (selectAllBtn != null)
+					selectAllBtn.Click += new RoutedEventHandler(SelectAll_Click);
+
+				var clearAllBtn = VisualTreeService.FindVisualChild<Button>(DropdownMenu.Child, PART_MultiSelectComboBox_Dropdown_ClearAllButton); ;//
+				if (clearAllBtn != null)
+					clearAllBtn.Click += new RoutedEventHandler(ClearAll_Click);				
 			}
 
 			if (ItemsSource != null)
@@ -502,7 +512,32 @@ namespace Sdl.MultiSelectComboBox.Themes.Generic
 				UpdateItems(SelectedItemsFilterTextBox?.Text ?? string.Empty);
 			}
 		}
+		private void SelectAll_Click(object sender, RoutedEventArgs e) {
+			foreach (var itm in ItemsSource) {
+				var does_this_work = DropdownListBox?.ItemContainerGenerator.ContainerFromItem(itm);
+				var listBoxItem = GetListViewItem(itm);
+				if (does_this_work == null && listBoxItem == null)
+					continue;
+				if (itm is IItemEnabledAware enabledAware  == false || enabledAware.IsEnabled)
+					listBoxItem.IsChecked = true;
+				
+			}
+				
+			UpdateSelectedItemsContainer(ItemsSource);
+		}
+		private void ClearAll_Click(object sender, RoutedEventArgs e) {
+			foreach (var itm in ItemsSource) {
+				var does_this_work = DropdownListBox?.ItemContainerGenerator.ContainerFromItem(itm);
+				var listBoxItem = GetListViewItem(itm);
+				if (does_this_work == null && listBoxItem == null)
+					continue;
+				if (itm is IItemEnabledAware enabledAware == false || enabledAware.IsEnabled)
+					listBoxItem.IsChecked = false;
 
+			}
+
+			UpdateSelectedItemsContainer(ItemsSource);
+		}
 		private void NewItemCreated_Click(object sender, RoutedEventArgs e) {
 			RaiseNewItemAddRequestEvent(TextBoxNewItem.Text);
 			TextBoxNewItem.Text = "";
@@ -621,6 +656,27 @@ namespace Sdl.MultiSelectComboBox.Themes.Generic
 			}
 		}
 
+		/// <summary>
+		/// Dependency property backing for the EnableSelectAllUI property.
+		/// </summary>
+		public static readonly DependencyProperty EnableSelectAllUIProperty =
+			DependencyProperty.Register(nameof(EnableSelectAllUI), typeof(bool), typeof(MultiSelectComboBox));
+		/// <summary>
+		/// Get or set the value indicating whether the Select All button is visible in the drop down.
+		/// </summary>
+		public bool EnableSelectAllUI {
+			get { return (bool)GetValue(EnableSelectAllUIProperty); }
+			set { SetValue(EnableSelectAllUIProperty, value); }
+		}
+		public static readonly DependencyProperty EnableClearAllUIProperty =
+			DependencyProperty.Register(nameof(EnableClearAllUI), typeof(bool), typeof(MultiSelectComboBox));
+		/// <summary>
+		/// Get or set the value indicating whether the Create New Item button is visible in the drop down.
+		/// </summary>
+		public bool EnableClearAllUI {
+			get { return (bool)GetValue(EnableClearAllUIProperty); }
+			set { SetValue(EnableClearAllUIProperty, value); }
+		}
 		/// <summary>
 		/// Dependency property backing for the EnableNewItemAddUI property.
 		/// </summary>
@@ -1437,6 +1493,7 @@ namespace Sdl.MultiSelectComboBox.Themes.Generic
 						if ( (Keyboard.IsKeyDown(Key.LeftCtrl) || Keyboard.IsKeyDown(Key.RightCtrl)) && EnableDeleteItemUI)
 						{
 							RaiseItemDeleteRequestEvent(new Collection<object>() { item });
+							e.Handled = true;
 						}
 						else
 							AttemptToRemoveSelectedItem(item);

--- a/MultiSelectComboBox/Sdl.MultiSelectComboBox/Themes/Generic/MultiSelectComboBox.cs
+++ b/MultiSelectComboBox/Sdl.MultiSelectComboBox/Themes/Generic/MultiSelectComboBox.cs
@@ -572,6 +572,14 @@ namespace Sdl.MultiSelectComboBox.Themes.Generic
 			add => AddHandler(NewItemAddRequestEvent, value);
 			remove => RemoveHandler(NewItemAddRequestEvent, value);
 		}
+		public static readonly RoutedEvent ItemDeleteRequestEvent =
+			EventManager.RegisterRoutedEvent(nameof(ItemDeleteRequest), RoutingStrategy.Direct,
+				typeof(EventHandler<ItemDeleteRequestEventArgs>), typeof(MultiSelectComboBox));
+
+		public event EventHandler<ItemDeleteRequestEventArgs> ItemDeleteRequest {
+			add => AddHandler(ItemDeleteRequestEvent, value);
+			remove => RemoveHandler(ItemDeleteRequestEvent, value);
+		}
 
 		public static readonly RoutedEvent FilterTextChangedEvent =
 			EventManager.RegisterRoutedEvent("FilterTextChanged", RoutingStrategy.Direct,
@@ -614,7 +622,7 @@ namespace Sdl.MultiSelectComboBox.Themes.Generic
 		}
 
 		/// <summary>
-		/// Dependency property backing for the IsCreateNewEnabled property.
+		/// Dependency property backing for the EnableNewItemAddUI property.
 		/// </summary>
 		public static readonly DependencyProperty EnableNewItemAddUIProperty =
 			DependencyProperty.Register(nameof(EnableNewItemAddUI), typeof(bool), typeof(MultiSelectComboBox));
@@ -625,6 +633,22 @@ namespace Sdl.MultiSelectComboBox.Themes.Generic
 			get { return (bool)GetValue(EnableNewItemAddUIProperty); }
 			set { SetValue(EnableNewItemAddUIProperty, value); }
 		}
+			
+
+		/// <summary>
+		/// Dependency property backing for the EnableDeleteItemUI property.
+		/// </summary>
+		public static readonly DependencyProperty EnableDeleteItemUIProperty =
+			DependencyProperty.Register(nameof(EnableDeleteItemUI), typeof(bool), typeof(MultiSelectComboBox));
+		
+		/// <summary>
+		/// Get or set the value indicating whether the Delete Item button is visible in the drop down.
+		/// </summary>
+		public bool EnableDeleteItemUI {
+			get { return (bool)GetValue(EnableDeleteItemUIProperty); }
+			set { SetValue(EnableDeleteItemUIProperty, value); }
+		}
+
 
 		public static readonly DependencyProperty EnableFilteringProperty =
 			DependencyProperty.Register("EnableFiltering", typeof(bool), typeof(MultiSelectComboBox),
@@ -1189,6 +1213,15 @@ namespace Sdl.MultiSelectComboBox.Themes.Generic
 					RaiseEvent(args);
 				}));
 		}
+
+		private void RaiseItemDeleteRequestEvent(ICollection items) {
+
+			Dispatcher.BeginInvoke(new Action(
+			delegate {
+				var args = new ItemDeleteRequestEventArgs(ItemDeleteRequestEvent, items);
+				RaiseEvent(args);
+			}));
+		}
 		private void RaiseFilterTextChangedEvent()
 		{
 			Dispatcher.BeginInvoke(new Action(
@@ -1401,7 +1434,12 @@ namespace Sdl.MultiSelectComboBox.Themes.Generic
 					var element = e.OriginalSource as FrameworkElement;
 					if (element?.DataContext is object item)
 					{
-						AttemptToRemoveSelectedItem(item);
+						if ( (Keyboard.IsKeyDown(Key.LeftCtrl) || Keyboard.IsKeyDown(Key.RightCtrl)) && EnableDeleteItemUI)
+						{
+							RaiseItemDeleteRequestEvent(new Collection<object>() { item });
+						}
+						else
+							AttemptToRemoveSelectedItem(item);
 					}
 				}
 				else

--- a/MultiSelectComboBox/Sdl.MultiSelectComboBox/Themes/Generic/MultiSelectComboBox.cs
+++ b/MultiSelectComboBox/Sdl.MultiSelectComboBox/Themes/Generic/MultiSelectComboBox.cs
@@ -752,7 +752,7 @@ namespace Sdl.MultiSelectComboBox.Themes.Generic
 		{
 			foreach (var item in basedOn)
 			{
-				if (AddSelectedItem(to, item))
+				if (AddSelectedItem(to, item, basedOn))
 				{
 					itemsAdded.Add(item);
 					if (control.SelectionMode == SelectionModes.Single)
@@ -764,21 +764,29 @@ namespace Sdl.MultiSelectComboBox.Themes.Generic
 			}
 		}
 
-		private static bool AddSelectedItem(IList to, object item)
+		private static bool AddSelectedItem(IList to, object item, IList sourceList = null)
 		{
 			if (to.Contains(item))
 			{
 				return false;
 			}
+			var insert_at = sourceList?.IndexOf(item) ?? -1;
+			if (insert_at == -1)
+				insert_at = to.Count;
+			var debug_orig_at = insert_at;
+			if (to.Count < insert_at)
+				insert_at = to.Count;
 
-			if (to.Count > 0 && to[to.Count - 1] == null)
+			if (to.Count > 0 && insert_at > 0 && to[insert_at - 1] == null)
 			{
-				to.Insert(to.Count - 1, item);
+				insert_at--;
 			}
-			else
+			if (insert_at == to.Count)
 			{
 				to.Add(item);
 			}
+			else
+				to.Insert(insert_at, item);
 
 			return true;
 		}
@@ -850,7 +858,7 @@ namespace Sdl.MultiSelectComboBox.Themes.Generic
 				_isWaitingToHandleSelectedItemsChanged = true;
 				Dispatcher.BeginInvoke((Action)delegate
 				{
-					HandleSelectedItemsChanged();
+					HandleSelectedItemsChanged(e.Action == NotifyCollectionChangedAction.Move ?  e.OldItems : null);
 					_isWaitingToHandleSelectedItemsChanged = false;
 				}, DispatcherPriority.ContextIdle);
 			}
@@ -859,7 +867,7 @@ namespace Sdl.MultiSelectComboBox.Themes.Generic
 		private bool _isWaitingToHandleSelectedItemsChanged;
 		private bool _isHandlingSelectedItemInternally;
 
-        private void HandleSelectedItemsChanged()
+		private void HandleSelectedItemsChanged(IList items_if_only_move=null)
 		{
 			if (SelectedItems == null)
 			{
@@ -870,11 +878,16 @@ namespace Sdl.MultiSelectComboBox.Themes.Generic
 			var itemsRemoved = new Collection<object>();
 
 			RemoveSelectedItems(SelectedItemsInternal, SelectedItems, ref itemsRemoved);
+			if (items_if_only_move != null) {//remove and then just re-add 
+				foreach (var itm in items_if_only_move) {
+					if (SelectedItemsInternal.Remove(itm))
+						itemsRemoved.Add(itm);
+				}
+			}
 			AddSelectedItems(SelectedItemsInternal, SelectedItems, ref itemsAdded, this);
 
-			ToggleDropdownListItemsCheckState(itemsAdded, true);
 			ToggleDropdownListItemsCheckState(itemsRemoved, false);
-
+			ToggleDropdownListItemsCheckState(itemsAdded, true);
             _isHandlingSelectedItemInternally = true;
 			SelectedItem = SelectedItems.Cast<object>().FirstOrDefault();
             _isHandlingSelectedItemInternally = false;

--- a/MultiSelectComboBox/Sdl.MultiSelectComboBox/Themes/Generic/MultiSelectComboBox.cs
+++ b/MultiSelectComboBox/Sdl.MultiSelectComboBox/Themes/Generic/MultiSelectComboBox.cs
@@ -1861,6 +1861,8 @@ namespace Sdl.MultiSelectComboBox.Themes.Generic
 
 		private void AssignIsEditMode()
 		{
+			if (SelectedItemsInternal?.Count == 0)//no placeholder exists by default
+				SelectedItemsInternal.Add(null);
 			SetValue(IsEditModePropertyKey, true);
 
 			FocusCursorOnFilterTextBox();

--- a/MultiSelectComboBox/Sdl.MultiSelectComboBox/Themes/Generic/MultiSelectComboBox.cs
+++ b/MultiSelectComboBox/Sdl.MultiSelectComboBox/Themes/Generic/MultiSelectComboBox.cs
@@ -401,11 +401,14 @@ namespace Sdl.MultiSelectComboBox.Themes.Generic
 			MultiSelectComboBox comboBox = sender as MultiSelectComboBox;
 			if (comboBox != null)
 			{
+				if (comboBox.IsDropDownOpen)
+					comboBox.IgnoreDropdownClosingFocusPlanUntil = DateTime.Now.AddSeconds(1);
 				comboBox.CloseDropdownMenu(comboBox.ClearFilterOnDropdownClosing, false);
 				comboBox.CaptureMouse();
 				comboBox.ReleaseMouseCapture();
 			}
 		}
+		private DateTime? IgnoreDropdownClosingFocusPlanUntil;
 
 		public override void OnApplyTemplate()
 		{
@@ -1385,6 +1388,11 @@ namespace Sdl.MultiSelectComboBox.Themes.Generic
 
 		private void DropdownMenuClosed(object sender, System.EventArgs e)
 		{
+			if (IgnoreDropdownClosingFocusPlanUntil > DateTime.Now)
+			{
+				IgnoreDropdownClosingFocusPlanUntil = null;//so only the first is ignored
+				return;
+			}
 			FocusCursorOnFilterTextBox();
 		}
 

--- a/MultiSelectComboBox/Sdl.MultiSelectComboBox/Themes/Generic/MultiSelectComboBox.cs
+++ b/MultiSelectComboBox/Sdl.MultiSelectComboBox/Themes/Generic/MultiSelectComboBox.cs
@@ -41,10 +41,12 @@ namespace Sdl.MultiSelectComboBox.Themes.Generic
 		private const string PART_MultiSelectComboBox_SelectedItemsPanel_Filter_TextBox = "PART_MultiSelectComboBox_SelectedItemsPanel_Filter_TextBox";
 		private const string PART_MultiSelectComboBox_SelectedItemsPanel_Filter_AutoComplete_TextBox = "PART_MultiSelectComboBox_SelectedItemsPanel_Filter_AutoComplete_TextBox";
 		private const string PART_MultiSelectComboBox_SelectedItemsPanel_RemoveItem_Button = "PART_MultiSelectComboBox_SelectedItemsPanel_RemoveItem_Button";
-
-		private const string MultiSelectComboBox_SelectedItems_ItemTemplate = "MultiSelectComboBox.SelectedItems.ItemTemplate";
+		private const string PART_MultiSelectComboBox_Dropdown_NewItem_CreatedOkButton = "PART_MultiSelectComboBox_Dropdown_NewItem_CreatedOkButton";
+		private const string PART_MultiSelectComboBox_Dropdown_NewItem_TextBox = "PART_MultiSelectComboBox_Dropdown_NewItem_TextBox";
 		private const string MultiSelectComboBox_SelectedItems_Searchable_ItemTemplate = "MultiSelectComboBox.SelectedItems.Searchable.ItemTemplate";
 		private const string MultiSelectComboBox_Dropdown_ListBox_ItemTemplate = "MultiSelectComboBox.Dropdown.ListBox.ItemTemplate";
+
+		private const string MultiSelectComboBox_SelectedItems_ItemTemplate = "MultiSelectComboBox.SelectedItems.ItemTemplate";
 
 		public MultiSelectComboBox()
 		{
@@ -448,7 +450,7 @@ namespace Sdl.MultiSelectComboBox.Themes.Generic
 				ApplyInternalTemplates(child);
 			}
 		}
-
+		private TextBox TextBoxNewItem;
 		private void InitializeInternalElements()
 		{
 			if (SelectedItemsControl == null && MultiSelectComboBoxGrid != null)
@@ -466,6 +468,14 @@ namespace Sdl.MultiSelectComboBox.Themes.Generic
 				if (DropdownMenu != null)
 				{
 					DropdownListBox = VisualTreeService.FindVisualChild<ListBox>(DropdownMenu.Child, PART_MultiSelectComboBox_Dropdown_ListBox);
+				}
+				var newItemCreated = VisualTreeService.FindVisualChild<Button>(DropdownMenu.Child, PART_MultiSelectComboBox_Dropdown_NewItem_CreatedOkButton);
+				if (newItemCreated != null) {
+					TextBoxNewItem = VisualTreeService.FindVisualChild<TextBox>(DropdownMenu.Child, PART_MultiSelectComboBox_Dropdown_NewItem_TextBox);
+					if (TextBoxNewItem != null) {
+						newItemCreated.Click += new RoutedEventHandler(NewItemCreated_Click);
+						TextBoxNewItem.KeyDown += (s, e) => { if (e.Key == Key.Enter) { e.Handled = true; NewItemCreated_Click(newItemCreated, null); } };
+					}
 				}
 			}
 
@@ -493,6 +503,10 @@ namespace Sdl.MultiSelectComboBox.Themes.Generic
 			}
 		}
 
+		private void NewItemCreated_Click(object sender, RoutedEventArgs e) {
+			RaiseNewItemAddRequestEvent(TextBoxNewItem.Text);
+			TextBoxNewItem.Text = "";
+		}
 		public enum SelectionModes
 		{
 			Multiple = 0,
@@ -549,6 +563,16 @@ namespace Sdl.MultiSelectComboBox.Themes.Generic
 			set => SetValue(AutoCompleteMaxLengthProperty, value);
 		}
 
+		public static readonly RoutedEvent NewItemAddRequestEvent =
+			EventManager.RegisterRoutedEvent(nameof(NewItemAddRequest), RoutingStrategy.Direct,
+				typeof(EventHandler<NewItemAddRequestEventArgs>), typeof(MultiSelectComboBox));
+
+		public event EventHandler<NewItemAddRequestEventArgs> NewItemAddRequest
+		{
+			add => AddHandler(NewItemAddRequestEvent, value);
+			remove => RemoveHandler(NewItemAddRequestEvent, value);
+		}
+
 		public static readonly RoutedEvent FilterTextChangedEvent =
 			EventManager.RegisterRoutedEvent("FilterTextChanged", RoutingStrategy.Direct,
 				typeof(EventHandler<FilterTextChangedEventArgs>), typeof(MultiSelectComboBox));
@@ -587,6 +611,19 @@ namespace Sdl.MultiSelectComboBox.Themes.Generic
 			{
 				control.ItemsCollectionViewSource = control.ItemsCollectionViewSource;
 			}
+		}
+
+		/// <summary>
+		/// Dependency property backing for the IsCreateNewEnabled property.
+		/// </summary>
+		public static readonly DependencyProperty EnableNewItemAddUIProperty =
+			DependencyProperty.Register(nameof(EnableNewItemAddUI), typeof(bool), typeof(MultiSelectComboBox));
+		/// <summary>
+		/// Get or set the value indicating whether the Create New Item button is visible in the drop down.
+		/// </summary>
+		public bool EnableNewItemAddUI {
+			get { return (bool)GetValue(EnableNewItemAddUIProperty); }
+			set { SetValue(EnableNewItemAddUIProperty, value); }
 		}
 
 		public static readonly DependencyProperty EnableFilteringProperty =
@@ -1144,6 +1181,14 @@ namespace Sdl.MultiSelectComboBox.Themes.Generic
 			}
 		}
 
+		private void RaiseNewItemAddRequestEvent(String TypedText) {
+			
+				Dispatcher.BeginInvoke(new Action(
+				delegate {
+					var args = new NewItemAddRequestEventArgs(NewItemAddRequestEvent, TypedText);
+					RaiseEvent(args);
+				}));
+		}
 		private void RaiseFilterTextChangedEvent()
 		{
 			Dispatcher.BeginInvoke(new Action(

--- a/MultiSelectComboBox/Sdl.MultiSelectComboBox/Themes/Generic/MultiSelectComboBox.cs
+++ b/MultiSelectComboBox/Sdl.MultiSelectComboBox/Themes/Generic/MultiSelectComboBox.cs
@@ -1335,7 +1335,7 @@ namespace Sdl.MultiSelectComboBox.Themes.Generic
 			}
 
             IsDropDownOpen = true;
-
+			
             if (DropdownListBox.Items.Count > 0)
             {
                 SetVisualFocusOnItem(DropdownListBox.SelectedItem);
@@ -1678,7 +1678,7 @@ namespace Sdl.MultiSelectComboBox.Themes.Generic
 			{
 				if (originalSource?.DataContext is object comboBoxItemTo)
 				{
-					var listBoxItemFrom = (IInputElement)DropdownListBox.ItemContainerGenerator.ContainerFromItem(DropdownListBox.SelectedItem);
+					var listBoxItemFrom = (IInputElement)DropdownListBox.ItemContainerGenerator.ContainerFromItem(comboBoxItemFrom);
 					var listBoxItemTo = (IInputElement)DropdownListBox.ItemContainerGenerator.ContainerFromItem(comboBoxItemTo);
 
 					if (listBoxItemFrom != null && listBoxItemTo != null)
@@ -1796,10 +1796,10 @@ namespace Sdl.MultiSelectComboBox.Themes.Generic
 							ItemsCollectionViewSource.View.MoveCurrentTo(comboBoxItem);
 							DropdownListBox.Items.MoveCurrentTo(comboBoxItem);
 						}
-
-						if (DropdownListBox.SelectedItem != null)
+						var selectedItem = DropdownListBox.SelectedItem;
+						if (selectedItem != null)
 						{
-							DropdownListBox.ScrollIntoView(DropdownListBox.SelectedItem);
+							DropdownListBox.ScrollIntoView(selectedItem);
 
 							UpdateAutoCompleteFilterText(FilterTextApplied, comboBoxItem);
 						}
@@ -2023,17 +2023,19 @@ namespace Sdl.MultiSelectComboBox.Themes.Generic
 
 		private void SelectComboBoxItem()
 		{
-			if (DropdownListBox.SelectedItem == null && DropdownListBox.Items.Count > 0)
+			var selectedItem = DropdownListBox.SelectedItem;
+			if (selectedItem == null && DropdownListBox.Items.Count > 0)
 			{
-				DropdownListBox.SelectedItem = DropdownListBox.Items[0];
+				selectedItem = DropdownListBox.SelectedItem = DropdownListBox.Items[0];//potential race
 			}
 
-			if (DropdownListBox.SelectedItem != null)
+			if (selectedItem != null)
 			{
-				var selectedItem = DropdownListBox.SelectedItem;
+				
 
 				var listBoxItem = GetListViewItem(selectedItem);
-				listBoxItem.IsChecked = true;
+				if (listBoxItem != null)//if removed in a race this could be null
+					listBoxItem.IsChecked = true;
 
 				UpdateSelectedItemsContainer(ItemsSource);
 			}

--- a/MultiSelectComboBox/Sdl.MultiSelectComboBox/Themes/Generic/MultiSelectComboBox.xaml
+++ b/MultiSelectComboBox/Sdl.MultiSelectComboBox/Themes/Generic/MultiSelectComboBox.xaml
@@ -3,6 +3,8 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:generic="clr-namespace:Sdl.MultiSelectComboBox.Themes.Generic"
     xmlns:api="clr-namespace:Sdl.MultiSelectComboBox.API"
+	xmlns:system="clr-namespace:System;assembly=mscorlib"
+
     xmlns:controls="clr-namespace:Sdl.MultiSelectComboBox.Controls">
 
 	<controls:PropertyExistsToBoolConverter x:Key="isEnabledPropertyExistsConverter" PropertyToCheck="IsEnabled" />
@@ -33,9 +35,12 @@
 
     <FontFamily x:Key="MultiSelectComboBox.Text.FontFamily">Segoe UI</FontFamily>
     <SolidColorBrush x:Key="MultiSelectComboBox.Text.Disabled.Foreground" Color="#FFB8B3B3"/>
-	<SolidColorBrush x:Key="MultiSelectComboBox.Text.WatermarkWhenEmpty.Foreground" Color="#FFB8B3B3"/>
-	<SolidColorBrush x:Key="MultiSelectComboBox.Text.WatermarkWhenNotEmpty.Foreground" Color="#000"/>
-	<Thickness x:Key="MultiSelectComboBox.Text.WatermarkNonEmptyFloat.Margin" Top="-20" />
+	<SolidColorBrush	x:Key="MultiSelectComboBox.SelectedItemsPanel.WatermarkWhenEmpty.Foreground" Color="#FFB8B3B3"/>
+	<system:Double		x:Key="MultiSelectComboBox.SelectedItemsPanel.WatermarkWhenEmpty.FontSize">14</system:Double>
+	<system:Double		x:Key="MultiSelectComboBox.SelectedItemsPanel.WatermarkWhenNotEmpty.FontSize">12</system:Double>
+	<SolidColorBrush	x:Key="MultiSelectComboBox.SelectedItemsPanel.WatermarkWhenNotEmpty.Foreground" Color="#000"/>
+	<Thickness			x:Key="MultiSelectComboBox.SelectedItemsPanel.WatermarkWhenNotEmpty.Margin" Top="-20" />
+	<FontWeight			x:Key="MultiSelectComboBox.SelectedItemsPanel.WatermarkWhenNotEmpty.FontWeight">Bold</FontWeight>
 	<controls:NumberComparisonToBoolConverter x:Key="numberAbove0ToBoolConverter" CompareToAmount="0" />
     <SolidColorBrush x:Key="MultiSelectComboBox.Text.Foreground" Color="#FF000000"/>
 
@@ -368,24 +373,27 @@
 								<Style TargetType="TextBlock">
 									<Setter Property="Visibility" Value="Collapsed"/>
 									<Setter Property="VerticalAlignment" Value="Center"/>
-									<Setter Property="FontSize" Value="16" />
+									<Setter Property="FontSize" Value="{StaticResource MultiSelectComboBox.SelectedItemsPanel.WatermarkWhenNotEmpty.FontSize}" />
 									<Setter Property="Margin" Value="0" />
-									<Setter Property="Foreground" Value="{StaticResource MultiSelectComboBox.Text.WatermarkWhenNotEmpty.Foreground}" />
+									<Setter Property="FontWeight" Value="Normal" />
+									<Setter Property="Foreground" Value="{StaticResource MultiSelectComboBox.SelectedItemsPanel.WatermarkWhenNotEmpty.Foreground}" />
 									<Style.Triggers>
 										<DataTrigger Binding="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type generic:MultiSelectComboBox}}, Path=SelectedItems.Count, Converter={StaticResource numberAbove0ToBoolConverter}}" Value="false">
 											<Setter Property="Visibility" Value="Visible"/>
-											<Setter Property="Foreground" Value="{StaticResource MultiSelectComboBox.Text.WatermarkWhenEmpty.Foreground}" />
+											<Setter Property="Foreground" Value="{StaticResource MultiSelectComboBox.SelectedItemsPanel.WatermarkWhenEmpty.Foreground}" />
+											<Setter Property="FontSize" Value="{StaticResource MultiSelectComboBox.SelectedItemsPanel.WatermarkWhenEmpty.FontSize}" />
 										</DataTrigger>
 
 										<MultiDataTrigger>
 											<MultiDataTrigger.Conditions>
-												<Condition Binding="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type generic:MultiSelectComboBox}}, Path=SelectedItems.Count, Converter={StaticResource numberAbove0ToBoolConverter}}" Value="true"/>
-												<Condition Binding="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type generic:MultiSelectComboBox}}, Path=WatermarkFloatOnNonEmpty}" Value="true"/>
+												<Condition Binding="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type generic:MultiSelectComboBox}}, Path=SelectedItems.Count, Converter={StaticResource numberAbove0ToBoolConverter}}" Value="True"/>
+												<Condition Binding="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type generic:MultiSelectComboBox}}, Path=WatermarkFloatOnNonEmpty}" Value="True"/>
 											</MultiDataTrigger.Conditions>
 											<Setter Property="Visibility" Value="Visible"/>
-											<Setter Property="Margin" Value="{StaticResource MultiSelectComboBox.Text.WatermarkNonEmptyFloat.Margin}"/>
+											<Setter Property="Margin" Value="{StaticResource MultiSelectComboBox.SelectedItemsPanel.WatermarkWhenNotEmpty.Margin}"/>
 											<Setter Property="VerticalAlignment" Value="Top" />
-											<Setter Property="FontSize" Value="12" />
+											<Setter Property="FontSize" Value="{StaticResource MultiSelectComboBox.SelectedItemsPanel.WatermarkWhenNotEmpty.FontSize}" />
+											<Setter Property="FontWeight" Value="{StaticResource MultiSelectComboBox.SelectedItemsPanel.WatermarkWhenNotEmpty.FontWeight}" />
 										</MultiDataTrigger>
 									</Style.Triggers>
 								</Style>

--- a/MultiSelectComboBox/Sdl.MultiSelectComboBox/Themes/Generic/MultiSelectComboBox.xaml
+++ b/MultiSelectComboBox/Sdl.MultiSelectComboBox/Themes/Generic/MultiSelectComboBox.xaml
@@ -32,6 +32,10 @@
 
     <FontFamily x:Key="MultiSelectComboBox.Text.FontFamily">Segoe UI</FontFamily>
     <SolidColorBrush x:Key="MultiSelectComboBox.Text.Disabled.Foreground" Color="#FFB8B3B3"/>
+	<SolidColorBrush x:Key="MultiSelectComboBox.Text.WatermarkWhenEmpty.Foreground" Color="#FFB8B3B3"/>
+	<SolidColorBrush x:Key="MultiSelectComboBox.Text.WatermarkWhenNotEmpty.Foreground" Color="#000"/>
+	<Thickness x:Key="MultiSelectComboBox.Text.WatermarkNonEmptyFloat.Margin" Top="-20" />
+	<controls:NumberComparisonToBoolConverter x:Key="numberAbove0ToBoolConverter" CompareToAmount="0" />
     <SolidColorBrush x:Key="MultiSelectComboBox.Text.Foreground" Color="#FF000000"/>
 
     <Style x:Key="MultiSelectComboBox.FocusVisual">
@@ -322,20 +326,21 @@
                 </Grid.ColumnDefinitions>
 
                 <Border Grid.Column="0" Margin="1" Background="White" BorderThickness="0">
-                    <controls:ContentItemsControl x:Name="PART_MultiSelectComboBox_SelectedItemsPanel_ItemsControl"                            
+					<Grid>
+						<controls:ContentItemsControl x:Name="PART_MultiSelectComboBox_SelectedItemsPanel_ItemsControl"
                             ItemContainerStyle="{StaticResource MultiSelectComboBox.SelectedItems.ItemContainer.Style}"                           
                             Style="{StaticResource MultiSelectComboBox.SelectedItemsPanel.WrapableItemsSource.Style}">
-                        <controls:ContentItemsControl.Resources>
-                            <DataTemplate x:Key="MultiSelectComboBox.SelectedItems.ItemTemplate">
-                                <TextBlock Text="{Binding}" Style="{DynamicResource MultiSelectComboBox.DefaultTextBlock.Style}" Margin="2,0" />
-                            </DataTemplate>
-                            <DataTemplate x:Key="MultiSelectComboBox.SelectedItems.Searchable.ItemTemplate">
+							<controls:ContentItemsControl.Resources>
+								<DataTemplate x:Key="MultiSelectComboBox.SelectedItems.ItemTemplate">
+									<TextBlock Text="{Binding}" Style="{DynamicResource MultiSelectComboBox.DefaultTextBlock.Style}" Margin="2,0" />
+								</DataTemplate>
+								<DataTemplate x:Key="MultiSelectComboBox.SelectedItems.Searchable.ItemTemplate">
                                 <StackPanel Name="TextBoxContainer" Orientation="Horizontal">
                                     <TextBox x:Name="PART_MultiSelectComboBox_SelectedItemsPanel_Filter_TextBox" IsEnabled="{Binding IsEditMode, RelativeSource={RelativeSource AncestorType=generic:MultiSelectComboBox}}" 
                                          Focusable="True" IsTabStop="False" Margin="0" ForceCursor="True" BorderThickness="0" BorderBrush="Transparent" Background="Transparent" Padding="1" TextWrapping="NoWrap"/>
-                                    <TextBox x:Name="PART_MultiSelectComboBox_SelectedItemsPanel_Filter_AutoComplete_TextBox" IsReadOnly="True"
+										<TextBox x:Name="PART_MultiSelectComboBox_SelectedItemsPanel_Filter_AutoComplete_TextBox" IsReadOnly="True"
                                          Focusable="False" IsTabStop="False" Margin="-2,0,0,0" BorderThickness="0" BorderBrush="Transparent" Background="Transparent" Padding="-3,1,0,1" TextWrapping="NoWrap"/>
-                                </StackPanel>
+									</StackPanel>
                                 <DataTemplate.Triggers>
                                     <MultiDataTrigger>
                                         <MultiDataTrigger.Conditions>
@@ -345,10 +350,42 @@
                                         <Setter TargetName="TextBoxContainer" Property="Visibility" Value="Collapsed"/>
                                     </MultiDataTrigger>
                                 </DataTemplate.Triggers>
-                            </DataTemplate>
-                        </controls:ContentItemsControl.Resources>
-                    </controls:ContentItemsControl>
-                </Border>
+								</DataTemplate>
+							</controls:ContentItemsControl.Resources>
+						</controls:ContentItemsControl>
+
+						<TextBlock HorizontalAlignment="Center" IsHitTestVisible="False" Text="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type generic:MultiSelectComboBox}}, Path=WatermarkEmptyHintText}">
+							<TextBlock.Style>
+								<Style TargetType="TextBlock">
+									<Setter Property="Visibility" Value="Collapsed"/>
+									<Setter Property="VerticalAlignment" Value="Center"/>
+									<Setter Property="FontSize" Value="16" />
+									<Setter Property="Margin" Value="0" />
+									<Setter Property="Foreground" Value="{StaticResource MultiSelectComboBox.Text.WatermarkWhenNotEmpty.Foreground}" />
+									<Style.Triggers>
+										<DataTrigger Binding="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type generic:MultiSelectComboBox}}, Path=SelectedItems.Count, Converter={StaticResource numberAbove0ToBoolConverter}}" Value="false">
+											<Setter Property="Visibility" Value="Visible"/>
+											<Setter Property="Foreground" Value="{StaticResource MultiSelectComboBox.Text.WatermarkWhenEmpty.Foreground}" />
+										</DataTrigger>
+
+										<MultiDataTrigger>
+											<MultiDataTrigger.Conditions>
+												<Condition Binding="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type generic:MultiSelectComboBox}}, Path=SelectedItems.Count, Converter={StaticResource numberAbove0ToBoolConverter}}" Value="true"/>
+												<Condition Binding="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type generic:MultiSelectComboBox}}, Path=WatermarkFloatOnNonEmpty}" Value="true"/>
+											</MultiDataTrigger.Conditions>
+											<Setter Property="Visibility" Value="Visible"/>
+											<Setter Property="Margin" Value="{StaticResource MultiSelectComboBox.Text.WatermarkNonEmptyFloat.Margin}"/>
+											<Setter Property="VerticalAlignment" Value="Top" />
+											<Setter Property="FontSize" Value="12" />
+										</MultiDataTrigger>
+									</Style.Triggers>
+								</Style>
+							</TextBlock.Style>
+						</TextBlock>
+
+					</Grid>
+			
+				</Border>
 
                 <Button x:Name="PART_MultiSelectComboBox_Dropdown_Button" Grid.Column="1" Style="{StaticResource MultiSelectComboBox.DropDown.Button.Style}" >
                     <ContentControl>

--- a/MultiSelectComboBox/Sdl.MultiSelectComboBox/Themes/Generic/MultiSelectComboBox.xaml
+++ b/MultiSelectComboBox/Sdl.MultiSelectComboBox/Themes/Generic/MultiSelectComboBox.xaml
@@ -1,4 +1,4 @@
-﻿<ResourceDictionary
+<ResourceDictionary
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:generic="clr-namespace:Sdl.MultiSelectComboBox.Themes.Generic"
@@ -17,6 +17,10 @@
     <SolidColorBrush x:Key="MultiSelectComboBox.DropDown.Button.MouseOver.Border" Color="#FF3C7FB1"/>
     <SolidColorBrush x:Key="MultiSelectComboBox.DropDown.Button.Pressed.Background" Color="#FFF4F4F4"/>
     <SolidColorBrush x:Key="MultiSelectComboBox.DropDown.Button.Pressed.Border" Color="#FF2C628B"/>
+	<SolidColorBrush x:Key="MultiSelectComboBox.DropDown.NewItem.Button.MouseOver.Background" Color="#FFF4F4F4"/>
+	<SolidColorBrush x:Key="MultiSelectComboBox.DropDown.NewItem.Button.MouseOver.Border" Color="#FF3C7FB1"/>
+	<SolidColorBrush x:Key="MultiSelectComboBox.DropDown.NewItem.Button.Pressed.Background" Color="#FFF4F4F4"/>
+	<SolidColorBrush x:Key="MultiSelectComboBox.DropDown.NewItem.Button.Pressed.Border" Color="#FF2C628B"/>
 
     <SolidColorBrush x:Key="MultiSelectComboBox.DropDown.ListBox.GroupHeader.Background" Color="#f7f7f7"/>
     <SolidColorBrush x:Key="MultiSelectComboBox.DropDown.ListBox.GroupHeader.Foreground" Color="Black"/>
@@ -108,7 +112,36 @@
             </Setter.Value>
         </Setter>
     </Style>
+	<Style x:Key="MultiSelectComboBox.DropDown.NewItem.Button.Style" TargetType="Button">
+		<Setter Property="OverridesDefaultStyle" Value="True" />
+		<Setter Property="FocusVisualStyle" Value="{StaticResource MultiSelectComboBox.FocusVisual}" />
+		<Setter Property="BorderThickness" Value="1" />
+		<Setter Property="TextBlock.FontSize" Value="10" />
+		<Setter Property="BorderBrush" Value="{x:Static SystemColors.WindowTextBrush}" />
+		<Setter Property="Template" >
+			<Setter.Value>
+				<ControlTemplate TargetType="Button">
+					<Border Padding="3,0" BorderBrush="{TemplateBinding BorderBrush}"
+                            BorderThickness="{TemplateBinding BorderThickness}"
+                            Background="{TemplateBinding Background}"
+                            SnapsToDevicePixels="True">
+						<ContentPresenter Content="{TemplateBinding Content}" />
+					</Border>
+				</ControlTemplate>
+			</Setter.Value>
+		</Setter>
+		<Style.Triggers>
+			<Trigger Property="IsMouseOver" Value="True">
+				<Setter Property="Background" Value="{StaticResource MultiSelectComboBox.DropDown.Button.MouseOver.Background}"/>
+				<Setter Property="BorderBrush" Value="{StaticResource MultiSelectComboBox.DropDown.Button.MouseOver.Border}"/>
+			</Trigger>
+			<Trigger Property="IsPressed" Value="True">
+				<Setter Property="Background" Value="{StaticResource MultiSelectComboBox.DropDown.NewItem.Button.Pressed.Background}"/>
+				<Setter Property="BorderBrush" Value="{StaticResource MultiSelectComboBox.DropDown.NewItem.Button.Pressed.Border}"/>
+			</Trigger>
+		</Style.Triggers>
 
+	</Style>
     <Style x:Key="MultiSelectComboBox.DropDown.Button.Style" TargetType="{x:Type Button}">
         <Setter Property="Background" Value="{StaticResource MultiSelectComboBox.DropDown.Button.Background}"/>
         <Setter Property="BorderBrush" Value="{StaticResource MultiSelectComboBox.DropDown.Button.Border}"/>
@@ -458,6 +491,11 @@
                                     <Canvas x:Name="canvas" HorizontalAlignment="Left" Height="0" VerticalAlignment="Top" Width="0">
                                         <Rectangle x:Name="opaqueRect" Fill="{Binding Background, ElementName=dropDownBorder}" Height="{Binding ActualHeight, ElementName=dropDownBorder}" Width="{Binding ActualWidth, ElementName=dropDownBorder}"/>
                                     </Canvas>
+									<Grid>
+										<Grid.RowDefinitions>
+											<RowDefinition />
+											<RowDefinition Height="Auto"/>
+										</Grid.RowDefinitions>
                                     <controls:ExtendedListBox x:Name="PART_MultiSelectComboBox_Dropdown_ListBox" Style="{StaticResource MultiSelectComboBox.Dropdown.ListBox.Style}">
                                         <controls:ExtendedListBox.GroupStyle>
                                             <GroupStyle HeaderTemplate="{StaticResource MultiSelectComboBox.Dropdown.ListBox.Header.Template}"/>
@@ -468,12 +506,67 @@
                                             </DataTemplate>
                                         </controls:ExtendedListBox.Resources>
                                     </controls:ExtendedListBox>
+										<Grid Name="PART_MultiSelectComboBox_Dropdown_EditBoxGrid" Visibility="Collapsed" Grid.Row="1" Margin="5" >
+											<Button Name="PART_MultiSelectComboBox_Dropdown_ShowEditBoxButton" HorizontalAlignment="Right" 
+                                         Style="{StaticResource MultiSelectComboBox.DropDown.NewItem.Button.Style}"
+                                        Content="Create New Item"
+                                        />
+											<Border Margin="3,0,3,3" Name="PART_MultiSelectComboBox_Dropdown_NewItem_EditGroup" Visibility="Collapsed">
+												<Grid>
+													<Grid.ColumnDefinitions>
+														<ColumnDefinition Width="*"/>
+														<ColumnDefinition Width="Auto"/>
+													</Grid.ColumnDefinitions>
+													<TextBox Grid.Column="0" Background="White" Name="PART_MultiSelectComboBox_Dropdown_NewItem_TextBox"/>
+													<Button Name="PART_MultiSelectComboBox_Dropdown_NewItem_CreatedOkButton" 
+                                            Grid.Column="1" 
+                                            Margin="3" 
+                                            Content="Ok" Style="{StaticResource MultiSelectComboBox.DropDown.NewItem.Button.Style}"
+                                            
+                                            />
+												</Grid>
+											</Border>
+										</Grid>
+									</Grid>
                                 </Grid>
                             </Border>
                         </Popup>
                     </Grid>
+					<ControlTemplate.Triggers>
+						<Trigger Property="EnableNewItemAddUI" Value="True">
+							<Setter TargetName="PART_MultiSelectComboBox_Dropdown_EditBoxGrid" Property="Visibility" Value="Visible" />
+						</Trigger>
+						<EventTrigger SourceName="PART_MultiSelectComboBox_Dropdown_ShowEditBoxButton" RoutedEvent="Button.Click">
+							<BeginStoryboard>
+								<Storyboard>
+									<ObjectAnimationUsingKeyFrames Storyboard.TargetName="PART_MultiSelectComboBox_Dropdown_NewItem_EditGroup" 
+                                                       Storyboard.TargetProperty="Visibility">
+										<DiscreteObjectKeyFrame KeyTime="00:00:00" Value="{x:Static Visibility.Visible}" />
+									</ObjectAnimationUsingKeyFrames>
+									<DoubleAnimation Storyboard.TargetName="PART_MultiSelectComboBox_Dropdown_ShowEditBoxButton" 
+                                         Storyboard.TargetProperty="Opacity" 
+                                         To="0" Duration="0:0:0"/>
+									<BooleanAnimationUsingKeyFrames Storyboard.TargetName="PART_MultiSelectComboBox_Dropdown_ShowEditBoxButton" Storyboard.TargetProperty="IsTabStop">
+										<DiscreteBooleanKeyFrame Value="False" KeyTime="0:0:0" />
+									</BooleanAnimationUsingKeyFrames>
+								</Storyboard>
+							</BeginStoryboard>
+						</EventTrigger>
+						<EventTrigger SourceName="PART_MultiSelectComboBox_Dropdown_NewItem_CreatedOkButton" RoutedEvent="Button.Click">
+							<BeginStoryboard>
+								<Storyboard>
+									<ObjectAnimationUsingKeyFrames BeginTime="00:00:00" Storyboard.TargetName="PART_MultiSelectComboBox_Dropdown_NewItem_EditGroup" Storyboard.TargetProperty="Visibility">
+										<DiscreteObjectKeyFrame KeyTime="00:00:00" Value="{x:Static Visibility.Collapsed}" />
+									</ObjectAnimationUsingKeyFrames>
+									<DoubleAnimation Storyboard.TargetName="PART_MultiSelectComboBox_Dropdown_ShowEditBoxButton" Storyboard.TargetProperty="Opacity" 
+                                             To="1" Duration="0:0:0"/>
+									<BooleanAnimationUsingKeyFrames Storyboard.TargetName="PART_MultiSelectComboBox_Dropdown_ShowEditBoxButton" Storyboard.TargetProperty="IsTabStop">
+										<DiscreteBooleanKeyFrame Value="True" KeyTime="0:0:0" />
+									</BooleanAnimationUsingKeyFrames>
 
-                    <ControlTemplate.Triggers>
+								</Storyboard>
+							</BeginStoryboard>
+						</EventTrigger>
                         <DataTrigger Binding="{Binding VerticalAlignment, RelativeSource={RelativeSource AncestorType=generic:MultiSelectComboBox}}" Value="Stretch">
                             <Setter TargetName="PART_MultiSelectComboBox" Property="MaxHeight" Value="{Binding ActualHeight, RelativeSource={RelativeSource AncestorType=generic:MultiSelectComboBox}}"/>
                         </DataTrigger>

--- a/MultiSelectComboBox/Sdl.MultiSelectComboBox/Themes/Generic/MultiSelectComboBox.xaml
+++ b/MultiSelectComboBox/Sdl.MultiSelectComboBox/Themes/Generic/MultiSelectComboBox.xaml
@@ -507,10 +507,15 @@
                                         </controls:ExtendedListBox.Resources>
                                     </controls:ExtendedListBox>
 										<Grid Name="PART_MultiSelectComboBox_Dropdown_EditBoxGrid" Visibility="Collapsed" Grid.Row="1" Margin="5" >
+											<StackPanel Orientation="Horizontal" HorizontalAlignment="Left" Name="PART_MultiSelectComboBox_Dropdown_LeftButtonsStackPanel">
+												<Button Name="PART_MultiSelectComboBox_Dropdown_ClearAllButton"   Visibility="Collapsed"
+													Style="{StaticResource MultiSelectComboBox.DropDown.NewItem.Button.Style}" Content="Clear All" Margin="3,0" />
+												<Button Name="PART_MultiSelectComboBox_Dropdown_SelectAllButton"   Visibility="Collapsed"
+													Style="{StaticResource MultiSelectComboBox.DropDown.NewItem.Button.Style}" Content="Select All" Margin="3,0" />
+											</StackPanel>
 											<Button Name="PART_MultiSelectComboBox_Dropdown_ShowEditBoxButton" HorizontalAlignment="Right" 
-                                         Style="{StaticResource MultiSelectComboBox.DropDown.NewItem.Button.Style}"
-                                        Content="Create New Item"
-                                        />
+                                         Style="{StaticResource MultiSelectComboBox.DropDown.NewItem.Button.Style}" Visibility="Collapsed"
+                                        Content="Create New Item"/>
 											<Border Margin="3,0,3,3" Name="PART_MultiSelectComboBox_Dropdown_NewItem_EditGroup" Visibility="Collapsed">
 												<Grid>
 													<Grid.ColumnDefinitions>
@@ -535,6 +540,15 @@
 					<ControlTemplate.Triggers>
 						<Trigger Property="EnableNewItemAddUI" Value="True">
 							<Setter TargetName="PART_MultiSelectComboBox_Dropdown_EditBoxGrid" Property="Visibility" Value="Visible" />
+							<Setter TargetName="PART_MultiSelectComboBox_Dropdown_ShowEditBoxButton" Property="Visibility" Value="Visible" />
+						</Trigger>
+						<Trigger Property="EnableSelectAllUI" Value="True">
+							<Setter TargetName="PART_MultiSelectComboBox_Dropdown_EditBoxGrid" Property="Visibility" Value="Visible" />
+							<Setter TargetName="PART_MultiSelectComboBox_Dropdown_SelectAllButton" Property="Visibility" Value="Visible" />
+						</Trigger>
+						<Trigger Property="EnableClearAllUI" Value="True">
+							<Setter TargetName="PART_MultiSelectComboBox_Dropdown_EditBoxGrid" Property="Visibility" Value="Visible" />
+							<Setter TargetName="PART_MultiSelectComboBox_Dropdown_ClearAllButton" Property="Visibility" Value="Visible" />
 						</Trigger>
 						<EventTrigger SourceName="PART_MultiSelectComboBox_Dropdown_ShowEditBoxButton" RoutedEvent="Button.Click">
 							<BeginStoryboard>
@@ -546,7 +560,16 @@
 									<DoubleAnimation Storyboard.TargetName="PART_MultiSelectComboBox_Dropdown_ShowEditBoxButton" 
                                          Storyboard.TargetProperty="Opacity" 
                                          To="0" Duration="0:0:0"/>
+									<DoubleAnimation Storyboard.TargetName="PART_MultiSelectComboBox_Dropdown_LeftButtonsStackPanel" 
+                                         Storyboard.TargetProperty="Opacity" 
+                                         To="0" Duration="0:0:0"/>
 									<BooleanAnimationUsingKeyFrames Storyboard.TargetName="PART_MultiSelectComboBox_Dropdown_ShowEditBoxButton" Storyboard.TargetProperty="IsTabStop">
+										<DiscreteBooleanKeyFrame Value="False" KeyTime="0:0:0" />
+									</BooleanAnimationUsingKeyFrames>
+									<BooleanAnimationUsingKeyFrames Storyboard.TargetName="PART_MultiSelectComboBox_Dropdown_ClearAllButton" Storyboard.TargetProperty="IsTabStop">
+										<DiscreteBooleanKeyFrame Value="False" KeyTime="0:0:0" />
+									</BooleanAnimationUsingKeyFrames>
+									<BooleanAnimationUsingKeyFrames Storyboard.TargetName="PART_MultiSelectComboBox_Dropdown_SelectAllButton" Storyboard.TargetProperty="IsTabStop">
 										<DiscreteBooleanKeyFrame Value="False" KeyTime="0:0:0" />
 									</BooleanAnimationUsingKeyFrames>
 								</Storyboard>
@@ -563,7 +586,14 @@
 									<BooleanAnimationUsingKeyFrames Storyboard.TargetName="PART_MultiSelectComboBox_Dropdown_ShowEditBoxButton" Storyboard.TargetProperty="IsTabStop">
 										<DiscreteBooleanKeyFrame Value="True" KeyTime="0:0:0" />
 									</BooleanAnimationUsingKeyFrames>
-
+									<DoubleAnimation Storyboard.TargetName="PART_MultiSelectComboBox_Dropdown_LeftButtonsStackPanel" Storyboard.TargetProperty="Opacity" 
+                                             To="1" Duration="0:0:0"/>
+									<BooleanAnimationUsingKeyFrames Storyboard.TargetName="PART_MultiSelectComboBox_Dropdown_SelectAllButton" Storyboard.TargetProperty="IsTabStop">
+										<DiscreteBooleanKeyFrame Value="True" KeyTime="0:0:0" />
+									</BooleanAnimationUsingKeyFrames>
+									<BooleanAnimationUsingKeyFrames Storyboard.TargetName="PART_MultiSelectComboBox_Dropdown_ClearAllButton" Storyboard.TargetProperty="IsTabStop">
+										<DiscreteBooleanKeyFrame Value="True" KeyTime="0:0:0" />
+									</BooleanAnimationUsingKeyFrames>
 								</Storyboard>
 							</BeginStoryboard>
 						</EventTrigger>

--- a/MultiSelectComboBox/Sdl.MultiSelectComboBox/Themes/Generic/MultiSelectComboBox.xaml
+++ b/MultiSelectComboBox/Sdl.MultiSelectComboBox/Themes/Generic/MultiSelectComboBox.xaml
@@ -5,6 +5,7 @@
     xmlns:api="clr-namespace:Sdl.MultiSelectComboBox.API"
     xmlns:controls="clr-namespace:Sdl.MultiSelectComboBox.Controls">
 
+	<controls:PropertyExistsToBoolConverter x:Key="isEnabledPropertyExistsConverter" PropertyToCheck="IsEnabled" />
     <SolidColorBrush x:Key="MultiSelectComboBox.DropDown.Button.Background" Color="Transparent"/>
     <SolidColorBrush x:Key="MultiSelectComboBox.DropDown.Button.Border" Color="#FF707070"/>
     <SolidColorBrush x:Key="MultiSelectComboBox.DropDown.Button.Disabled.Background" Color="#FFF4F4F4"/>
@@ -37,6 +38,7 @@
 	<Thickness x:Key="MultiSelectComboBox.Text.WatermarkNonEmptyFloat.Margin" Top="-20" />
 	<controls:NumberComparisonToBoolConverter x:Key="numberAbove0ToBoolConverter" CompareToAmount="0" />
     <SolidColorBrush x:Key="MultiSelectComboBox.Text.Foreground" Color="#FF000000"/>
+
 
     <Style x:Key="MultiSelectComboBox.FocusVisual">
         <Setter Property="Control.Template">
@@ -145,7 +147,12 @@
     </Style>
 
     <Style x:Key="MultiSelectComboBox.Dropdown.ListBox.ItemContainerStyle" TargetType="{x:Type controls:ExtendedListBoxItem}">
-        <Setter Property="SnapsToDevicePixels" Value="True"/>
+		<Style.Triggers>
+			<DataTrigger Binding="{Binding Converter={StaticResource isEnabledPropertyExistsConverter}}" Value="true">
+				<Setter Property="IsEnabled" Value="{Binding Path=IsEnabled}"/>
+			</DataTrigger>
+		</Style.Triggers>
+		<Setter Property="SnapsToDevicePixels" Value="True"/>
         <Setter Property="Padding" Value="1"/>
         <Setter Property="Margin" Value="0"/>
         <Setter Property="HorizontalContentAlignment" Value="{Binding HorizontalContentAlignment, RelativeSource={RelativeSource AncestorType={x:Type ItemsControl}}}"/>
@@ -153,7 +160,9 @@
         <Setter Property="Background" Value="Transparent"/>
         <Setter Property="BorderBrush" Value="Transparent"/>
         <Setter Property="BorderThickness" Value="0"/>
-        <Setter Property="IsEnabled" Value="{Binding Path=IsEnabled}"/>
+		<Setter Property="IsEnabled" Value="true"/>
+
+        
         <Setter Property="FocusVisualStyle" Value="{StaticResource MultiSelectComboBox.FocusVisual}"/>
         <Setter Property="Template">
             <Setter.Value>


### PR DESCRIPTION
This is not a PR I expect to get merged, infact nearly all the changes here are PR I previously put together and submitted for them to be declined.  I am submitting this up for anyone looking for the features to know where they can be found (as now just operating in one merged branch rather than keeping each feature separate). These are all rebased onto master so should play with other patches somewhat cleanly.

If any of these are desired as a separate PR let me know I can pull them out..


This adds the following:
- SelectAll, ClearAll Command bindings
- Delete item support with events
- New Item Add support (through entry at bottom of drop down) and events
- Proper change tracking and order preservation for binding of selected items to things like ObservableCollections.
- Watermark / placeholder hint support (including floating to act as a label when there is content)
- Fix for focus control steal issues around dropdown closing
- Fix for race condition on selected item changing which could cause a null pointer exception crash
